### PR TITLE
fix: remove duplicate pass_context decorator in CLI commands

### DIFF
--- a/litestar_mcp/cli.py
+++ b/litestar_mcp/cli.py
@@ -158,7 +158,6 @@ def mcp_group(ctx: "click.Context") -> None:
 
 
 @mcp_group.command(name="list-tools")  # type: ignore[misc]
-@click.pass_context
 def list_tools(ctx: click.Context) -> None:
     """List all available MCP tools."""
     plugin = ctx.obj["plugin"]  # pragma: no cover
@@ -171,6 +170,27 @@ def list_tools(ctx: click.Context) -> None:
     console.print(f"[bold green]Discovered {len(plugin.discovered_tools)} tools:[/bold green]")  # pragma: no cover
     for name in sorted(plugin.discovered_tools.keys()):  # pragma: no cover
         handler = plugin.discovered_tools[name]  # pragma: no cover
+        # Get the underlying function and its docstring  # pragma: no cover
+        fn = get_handler_function(handler)  # pragma: no cover
+        description = fn.__doc__ or "No description"  # pragma: no cover
+        # Clean up the description - take first line only  # pragma: no cover
+        first_line = description.split("\n")[0].strip()  # pragma: no cover
+        console.print(f"- [bold]{name}[/bold]: {first_line}")  # pragma: no cover
+
+
+@mcp_group.command(name="list-resources")  # type: ignore[misc]
+def list_resources(ctx: click.Context) -> None:
+    """List all available MCP resources."""
+    plugin = ctx.obj["plugin"]  # pragma: no cover
+    console = Console()  # pragma: no cover
+
+    if not plugin.discovered_resources:  # pragma: no cover
+        console.print("[yellow]No MCP resources discovered.[/yellow]")  # pragma: no cover
+        return  # pragma: no cover
+
+    console.print(f"[bold green]Discovered {len(plugin.discovered_resources)} resources:[/bold green]")  # pragma: no cover
+    for name in sorted(plugin.discovered_resources.keys()):  # pragma: no cover
+        handler = plugin.discovered_resources[name]  # pragma: no cover
         # Get the underlying function and its docstring  # pragma: no cover
         fn = get_handler_function(handler)  # pragma: no cover
         description = fn.__doc__ or "No description"  # pragma: no cover

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ maintainers = [
 name = "litestar-mcp"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.2.1"
+version = "0.2.2"
 
 [project.urls]
 Changelog = "https://docs.litestar-mcp.litestar.dev/latest/changelog"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,4 +27,5 @@ class TestCLI:
         assert result.exit_code == 0
         assert "Manage MCP tools and resources" in result.output
         assert "list-tools" in result.output
+        assert "list-resources" in result.output
         assert "run" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -985,7 +985,7 @@ wheels = [
 
 [[package]]
 name = "litestar-mcp"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Fixes TypeError when using CLI commands with the Litestar CLI system
- Removes duplicate `@click.pass_context` decorator that was causing context to be passed twice
- Adds `list-resources` command for consistency with MCP API

## Problem
When using `litestar_mcp` CLI commands in another project, the following error occurred:
```
TypeError: list_tools() got multiple values for argument 'ctx'
```

## Root Cause
The issue occurred because:
1. `LitestarGroup.command()` internally applies `@click.pass_context` through the `_inject_args` function
2. We were also explicitly adding `@click.pass_context` decorator in our code
3. This double decoration caused `ctx` to be passed twice to the function

## Changes
- Removed explicit `@click.pass_context` decorator from `list_tools` command
- Added `list-resources` command for consistency with the MCP REST API
- Updated test to verify both commands are available
- Bumped version to 0.2.2

## Test Verification
- All existing tests pass ✅
- Coverage maintained at 82% ✅
- Manually verified CLI commands work correctly ✅

Fixes the issue reported when using `uv run app mcp list-tools` in external projects.