### PR TITLE
docs: correct README runtime dependency and contribution notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This plugin automatically discovers routes marked with the `opt` attribute and e
 
 ## Features
 
-- 🚀 **Zero Dependencies** - Only requires Litestar
+- 🚀 **Minimal Runtime Dependencies** - Litestar plus lightweight helpers like `jsonschema` and `typing-extensions`
 - 📡 **Protocol-Native Transport** - MCP Streamable HTTP with JSON-RPC requests and SSE streams
 - 🔧 **Simple Route Marking** - Use Litestar's `opt` attribute pattern
 - 🛡️ **Type Safe** - Full type hints with dataclasses
@@ -270,4 +270,4 @@ MIT License. See [LICENSE](LICENSE) for details.
 
 ## Contributing
 
-Contributions welcome! Please see our [contributing guide](CONTRIBUTING.md) for details.
+Contributions welcome! Please see our [contribution guide](docs/contribution-guide.rst) for details.


### PR DESCRIPTION
## Summary
- correct the README feature bullet so it matches the actual runtime dependency set in `pyproject.toml`
- replace the broken `CONTRIBUTING.md` link with the real repository contribution guide path
- document only the README accuracy follow-up; the earlier transport/docs fixes are already present on current `main`
