### PR TITLE
feat: add MCP Prompts support (prompts/list, prompts/get)

### DIFF
--- a/litestar_mcp/__init__.py
+++ b/litestar_mcp/__init__.py
@@ -23,7 +23,7 @@ from litestar_mcp.auth import (
 from litestar_mcp.config import MCPConfig, MCPOptKeys
 from litestar_mcp.plugin import LitestarMCP
 from litestar_mcp.routes import MCPController
-from litestar_mcp.utils import mcp_resource, mcp_tool
+from litestar_mcp.utils import mcp_prompt, mcp_resource, mcp_tool
 
 __all__ = (
     "DefaultJWKSCache",
@@ -38,6 +38,7 @@ __all__ = (
     "TokenValidator",
     "__version__",
     "create_oidc_validator",
+    "mcp_prompt",
     "mcp_resource",
     "mcp_tool",
 )

--- a/litestar_mcp/__init__.py
+++ b/litestar_mcp/__init__.py
@@ -1,13 +1,16 @@
 """Litestar Model Context Protocol Integration Plugin.
 
-A lightweight plugin that exposes Litestar routes as MCP tools and resources
-via JSON-RPC 2.0 over Streamable HTTP. Mark a route handler by passing
-``mcp_tool="name"`` or ``mcp_resource="name"`` directly to the Litestar
-decorator — Litestar funnels unknown kwargs into ``handler.opt`` automatically,
-so no ``opt={...}`` wrapper or ``@mcp_tool`` / ``@mcp_resource`` second
-decorator is needed. The stacked decorator form is retained for parity (useful
-when you need ``output_schema`` / ``annotations`` / ``scopes`` /
-``task_support``) but the kwarg form is the recommended approach.
+A lightweight plugin that exposes Litestar routes as MCP tools, resources,
+and prompts via JSON-RPC 2.0 over Streamable HTTP. Mark a route handler by
+passing ``mcp_tool="name"``, ``mcp_resource="name"``, or
+``mcp_prompt="name"`` directly to the Litestar decorator — Litestar funnels
+unknown kwargs into ``handler.opt`` automatically, so no ``opt={...}``
+wrapper or ``@mcp_tool`` / ``@mcp_resource`` / ``@mcp_prompt`` second
+decorator is needed. The stacked decorator form is retained for parity
+(useful when you need ``output_schema`` / ``annotations`` / ``scopes`` /
+``task_support``) but the kwarg form is the recommended approach. Standalone
+prompts not bound to a route handler can also be registered via
+``LitestarMCP(prompts=[...])`` after decoration with ``@mcp_prompt``.
 """
 
 from litestar_mcp.__metadata__ import __version__

--- a/litestar_mcp/config.py
+++ b/litestar_mcp/config.py
@@ -23,11 +23,14 @@ class MCPOptKeys:
         resource_template: Opt key that carries an RFC 6570 Level 1 URI
             template for the resource (``handler.opt[resource_template] =
             "app://workspaces/{workspace_id}/files/{file_id}"``).
+        prompt: Opt key that marks a route handler as an MCP prompt
+            (``handler.opt[prompt] = "<prompt-name>"``).
         description: Opt key overriding the tool description
             (``handler.opt[description] = "LLM prose"``).
         resource_description: Opt key overriding the resource description.
             Kept distinct from ``description`` so a handler that exposes both
             a tool and a resource on the same route can target each.
+        prompt_description: Opt key overriding the prompt description.
         agent_instructions: Opt key for the ``## Instructions`` section.
         when_to_use: Opt key for the ``## When to use`` section.
         returns: Opt key for the ``## Returns`` section.
@@ -36,22 +39,27 @@ class MCPOptKeys:
     tool: str = "mcp_tool"
     resource: str = "mcp_resource"
     resource_template: str = "mcp_resource_template"
+    prompt: str = "mcp_prompt"
     description: str = "mcp_description"
     resource_description: str = "mcp_resource_description"
+    prompt_description: str = "mcp_prompt_description"
     agent_instructions: str = "mcp_agent_instructions"
     when_to_use: str = "mcp_when_to_use"
     returns: str = "mcp_returns"
 
-    def for_field(self, field_name: str, kind: Literal["tool", "resource"]) -> str:
+    def for_field(self, field_name: str, kind: Literal["tool", "resource", "prompt"]) -> str:
         """Return the opt key for ``(field_name, kind)``.
 
         The ``description`` field has kind-specific keys (``description`` for
-        tools, ``resource_description`` for resources) so a handler exposing
-        both a tool and a resource on the same route can carry distinct
-        override prose. All other fields are kind-agnostic.
+        tools, ``resource_description`` for resources, ``prompt_description``
+        for prompts) so a handler exposing multiple MCP roles on the same
+        route can carry distinct override prose. All other fields are
+        kind-agnostic.
         """
         if field_name == "description" and kind == "resource":
             return self.resource_description
+        if field_name == "description" and kind == "prompt":
+            return self.prompt_description
         value: str = getattr(self, field_name)
         return value
 

--- a/litestar_mcp/config.py
+++ b/litestar_mcp/config.py
@@ -31,6 +31,11 @@ class MCPOptKeys:
             Kept distinct from ``description`` so a handler that exposes both
             a tool and a resource on the same route can target each.
         prompt_description: Opt key overriding the prompt description.
+        prompt_title: Opt key overriding the prompt title.
+        prompt_arguments: Opt key overriding the prompt argument list (a
+            ``list[dict]`` matching the decorator's ``arguments=`` param).
+        prompt_icons: Opt key overriding the prompt icons list (a
+            ``list[dict]`` matching the decorator's ``icons=`` param).
         agent_instructions: Opt key for the ``## Instructions`` section.
         when_to_use: Opt key for the ``## When to use`` section.
         returns: Opt key for the ``## Returns`` section.
@@ -43,6 +48,9 @@ class MCPOptKeys:
     description: str = "mcp_description"
     resource_description: str = "mcp_resource_description"
     prompt_description: str = "mcp_prompt_description"
+    prompt_title: str = "mcp_prompt_title"
+    prompt_arguments: str = "mcp_prompt_arguments"
+    prompt_icons: str = "mcp_prompt_icons"
     agent_instructions: str = "mcp_agent_instructions"
     when_to_use: str = "mcp_when_to_use"
     returns: str = "mcp_returns"

--- a/litestar_mcp/executor.py
+++ b/litestar_mcp/executor.py
@@ -99,14 +99,21 @@ class MCPToolErrorResult(Exception):  # noqa: N818
     the ``tools/call`` result.
     """
 
-    def __init__(self, content: Any) -> None:
+    def __init__(self, content: Any, *, status_code: int = 500) -> None:
         """Initialize with the already-rendered JSON-RPC content payload.
 
         Args:
             content: Decoded response body (typically a ``dict``).
+            status_code: HTTP status code from the handler response.
         """
         super().__init__("MCP tool returned error response")
         self.content = content
+        self.status_code = status_code
+
+    @property
+    def is_client_error(self) -> bool:
+        """``True`` when the status code is in the 4xx range."""
+        return 400 <= self.status_code < 500
 
 
 async def _enforce_guards(handler: BaseRouteHandler, request: Request[Any, Any, Any]) -> None:
@@ -251,11 +258,11 @@ async def _dispatch_via_exception_handlers(
     handler: BaseRouteHandler,
     request: Request[Any, Any, Any],
     exc: Exception,
-) -> tuple[Any, bool] | None:
+) -> tuple[Any, int] | None:
     """Walk ``handler.resolve_exception_handlers()`` MRO-style for ``exc``.
 
     Returns:
-        ``(content, is_error)`` when a handler matches and renders a
+        ``(content, status_code)`` when a handler matches and renders a
         response; ``None`` when no handler matches (caller must re-raise).
     """
     exception_handlers = handler.resolve_exception_handlers() or {}
@@ -274,12 +281,11 @@ async def _dispatch_via_exception_handlers(
 
     if isinstance(raw, Response):
         status = int(getattr(raw, "status_code", 200))
-        is_error = status >= _ERROR_STATUS_FLOOR
-        return raw.content, is_error
+        return raw.content, status
 
     # Exception handler returned raw data — treat as an error render since
     # it was triggered by a raised exception.
-    return raw, True
+    return raw, 500
 
 
 _PATH_PARAMETERS_CACHE: weakref.WeakKeyDictionary[Any, dict[str, Any]] = weakref.WeakKeyDictionary()
@@ -588,7 +594,7 @@ async def execute_tool(
         )
 
         content: Any = None
-        is_error = False
+        status = 200
         try:
             try:
                 await _enforce_guards(handler, dispatch_request)
@@ -611,16 +617,15 @@ async def execute_tool(
                 http_handler = cast("HTTPRouteHandler", handler)
                 asgi_app = await http_handler.to_response(app=app, data=raw_result, request=dispatch_request)
                 content, status = await _capture_asgi_response(asgi_app, dispatch_request)
-                is_error = status >= _ERROR_STATUS_FLOOR
             except Exception as exc:
                 await _run_after_exception_hooks(app, dispatch_request, exc)
                 handled = await _dispatch_via_exception_handlers(handler, dispatch_request, exc)
                 if handled is None:
                     raise
-                content, is_error = handled
+                content, status = handled
         finally:
             await _run_after_response(handler, dispatch_request)
 
-    if is_error:
-        raise MCPToolErrorResult(content)
+    if status >= _ERROR_STATUS_FLOOR:
+        raise MCPToolErrorResult(content, status_code=status)
     return content

--- a/litestar_mcp/executor.py
+++ b/litestar_mcp/executor.py
@@ -242,6 +242,16 @@ async def _capture_asgi_response(
 
     await asgi_app(cast("Any", request.scope), cast("Any", request.receive), _sink_send)
 
+    if status_code == 0:
+        # ASGI app exited without sending http.response.start. Treat as a
+        # transport invariant violation rather than a 0-status success — the
+        # downstream caller would otherwise pass the (None, 0) result through
+        # the < _ERROR_STATUS_FLOOR check and surface "None" as a successful body.
+        return (
+            {"error": "MCP handler exited without sending an ASGI response"},
+            _NON_JSON_STATUS,
+        )
+
     body = b"".join(body_chunks)
     if not body:
         return None, status_code

--- a/litestar_mcp/executor.py
+++ b/litestar_mcp/executor.py
@@ -46,6 +46,7 @@ __all__ = (
     "MCPPathParamCoercionError",
     "MCPToolErrorResult",
     "NotCallableInCLIContextError",
+    "execute_handler",
     "execute_tool",
 )
 
@@ -629,3 +630,10 @@ async def execute_tool(
     if status >= _ERROR_STATUS_FLOOR:
         raise MCPToolErrorResult(content, status_code=status)
     return content
+
+
+# Generic alias used by non-tool MCP primitives (resources, prompts) that
+# dispatch through the same Litestar pipeline. Keeping a thin alias instead
+# of a single name avoids implying that the prompt/resource path is
+# semantically a "tool call" — the underlying machinery is the same.
+execute_handler = execute_tool

--- a/litestar_mcp/jsonrpc.py
+++ b/litestar_mcp/jsonrpc.py
@@ -1,9 +1,12 @@
 # ruff: noqa: N818, PLR0911, BLE001
 """JSON-RPC 2.0 message routing for MCP."""
 
+import logging
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass, field
 from typing import Any
+
+_logger = logging.getLogger(__name__)
 
 # Standard JSON-RPC 2.0 error codes
 PARSE_ERROR = -32700
@@ -109,11 +112,20 @@ class JSONRPCRouter:
                 return None
             return _error_response(request.id, exc.error)
         except Exception as exc:
+            # Blanket catch: any uncaught handler exception becomes
+            # INTERNAL_ERROR. Log with traceback so production triage
+            # has more than the wire payload to work from — silent
+            # -32603 in callers is otherwise undebugable.
+            _logger.exception("JSON-RPC handler %r raised", request.method)
             if request.is_notification:
                 return None
             return _error_response(
                 request.id,
-                JSONRPCError(code=INTERNAL_ERROR, message=str(exc)),
+                JSONRPCError(
+                    code=INTERNAL_ERROR,
+                    message="Internal error",
+                    data={"error": type(exc).__name__, "detail": str(exc)},
+                ),
             )
         else:
             if request.is_notification:

--- a/litestar_mcp/manifests.py
+++ b/litestar_mcp/manifests.py
@@ -116,6 +116,7 @@ def build_mcp_server_manifest(
     app: Litestar,
     discovered_tools: dict[str, Any],
     discovered_resources: dict[str, Any],
+    discovered_prompts: dict[str, Any],
 ) -> dict[str, Any]:
     """Build an experimental MCP server manifest."""
     tools = []
@@ -133,6 +134,17 @@ def build_mcp_server_manifest(
             tool_entry["security"] = {"scopes": metadata["scopes"]}
         tools.append(tool_entry)
 
+    prompts_list = []
+    if discovered_prompts:
+        for _name, registration in sorted(discovered_prompts.items()):
+            prompt_entry: dict[str, Any] = {"name": registration.name}
+            if registration.description is not None:
+                prompt_entry["description"] = registration.description
+            arguments = registration.get_arguments()
+            if arguments:
+                prompt_entry["arguments"] = arguments
+            prompts_list.append(prompt_entry)
+
     return {
         "experimental": True,
         "name": _server_name(config, app),
@@ -146,8 +158,10 @@ def build_mcp_server_manifest(
         "capabilities": {
             "tools": {"listChanged": True},
             "resources": {"subscribe": True, "listChanged": True},
+            "prompts": {"listChanged": True},
             "tasks": config.task_config is not None,
         },
         "tools": tools,
         "resources": sorted(discovered_resources.keys()),
+        "prompts": prompts_list,
     }

--- a/litestar_mcp/manifests.py
+++ b/litestar_mcp/manifests.py
@@ -6,6 +6,7 @@ from litestar import Litestar
 
 from litestar_mcp.auth import MCPAuthConfig  # noqa: TC001
 from litestar_mcp.config import MCPConfig
+from litestar_mcp.registry import render_prompt_entry
 from litestar_mcp.schema_builder import generate_schema_for_handler
 from litestar_mcp.utils import get_handler_function, get_mcp_metadata, render_description
 
@@ -134,24 +135,7 @@ def build_mcp_server_manifest(
             tool_entry["security"] = {"scopes": metadata["scopes"]}
         tools.append(tool_entry)
 
-    prompts_list = []
-    for _name, registration in discovered_prompts.items():
-        prompt_entry: dict[str, Any] = {"name": registration.name}
-        if registration.title is not None:
-            prompt_entry["title"] = registration.title
-        if registration.handler is not None:
-            fn = get_handler_function(registration.handler)
-            prompt_entry["description"] = render_description(
-                registration.handler, fn, kind="prompt", fallback_name=registration.name, opt_keys=config.opt_keys
-            )
-        elif registration.description is not None:
-            prompt_entry["description"] = registration.description
-        arguments = registration.get_arguments()
-        if arguments:
-            prompt_entry["arguments"] = arguments
-        if registration.icons is not None:
-            prompt_entry["icons"] = registration.icons
-        prompts_list.append(prompt_entry)
+    prompts_list = [render_prompt_entry(registration, config) for registration in discovered_prompts.values()]
 
     return {
         "experimental": True,

--- a/litestar_mcp/manifests.py
+++ b/litestar_mcp/manifests.py
@@ -136,7 +136,7 @@ def build_mcp_server_manifest(
 
     prompts_list = []
     if discovered_prompts:
-        for _name, registration in sorted(discovered_prompts.items()):
+        for _name, registration in discovered_prompts.items():
             prompt_entry: dict[str, Any] = {"name": registration.name}
             if registration.description is not None:
                 prompt_entry["description"] = registration.description

--- a/litestar_mcp/manifests.py
+++ b/litestar_mcp/manifests.py
@@ -150,7 +150,7 @@ def build_mcp_server_manifest(
         if arguments:
             prompt_entry["arguments"] = arguments
         if registration.icons is not None:
-            prompt_entry.setdefault("_meta", {})["icons"] = registration.icons
+            prompt_entry["icons"] = registration.icons
         prompts_list.append(prompt_entry)
 
     return {

--- a/litestar_mcp/manifests.py
+++ b/litestar_mcp/manifests.py
@@ -6,7 +6,7 @@ from litestar import Litestar
 
 from litestar_mcp.auth import MCPAuthConfig  # noqa: TC001
 from litestar_mcp.config import MCPConfig
-from litestar_mcp.registry import render_prompt_entry
+from litestar_mcp.registry import render_prompt_entry, should_include_prompt
 from litestar_mcp.schema_builder import generate_schema_for_handler
 from litestar_mcp.utils import get_handler_function, get_mcp_metadata, render_description
 
@@ -135,7 +135,19 @@ def build_mcp_server_manifest(
             tool_entry["security"] = {"scopes": metadata["scopes"]}
         tools.append(tool_entry)
 
-    prompts_list = [render_prompt_entry(registration, config) for registration in discovered_prompts.values()]
+    visible_prompts = [registration for registration in discovered_prompts.values() if should_include_prompt(registration, config)]
+    prompts_list = [render_prompt_entry(registration, config) for registration in visible_prompts]
+
+    capabilities: dict[str, Any] = {
+        "tools": {"listChanged": True},
+        "resources": {"subscribe": True, "listChanged": True},
+        "tasks": config.task_config is not None,
+    }
+    # Per the MCP spec a server SHOULD only advertise capabilities for primitives
+    # it actually exposes. tools/resources stay unconditional to preserve
+    # historical manifest behavior; prompts are gated to match handle_initialize.
+    if visible_prompts:
+        capabilities["prompts"] = {"listChanged": True}
 
     return {
         "experimental": True,
@@ -147,12 +159,7 @@ def build_mcp_server_manifest(
             "oauthProtectedResource": f"{base_url.rstrip('/')}/.well-known/oauth-protected-resource",
             "agentCard": f"{base_url.rstrip('/')}/.well-known/agent-card.json",
         },
-        "capabilities": {
-            "tools": {"listChanged": True},
-            "resources": {"subscribe": True, "listChanged": True},
-            "prompts": {"listChanged": True},
-            "tasks": config.task_config is not None,
-        },
+        "capabilities": capabilities,
         "tools": tools,
         "resources": sorted(discovered_resources.keys()),
         "prompts": prompts_list,

--- a/litestar_mcp/manifests.py
+++ b/litestar_mcp/manifests.py
@@ -135,22 +135,23 @@ def build_mcp_server_manifest(
         tools.append(tool_entry)
 
     prompts_list = []
-    if discovered_prompts:
-        for _name, registration in discovered_prompts.items():
-            prompt_entry: dict[str, Any] = {"name": registration.name}
-            if registration.title is not None:
-                prompt_entry["title"] = registration.title
-            if registration.handler is not None:
-                fn = get_handler_function(registration.handler)
-                prompt_entry["description"] = render_description(
-                    registration.handler, fn, kind="prompt", fallback_name=registration.name, opt_keys=config.opt_keys
-                )
-            elif registration.description is not None:
-                prompt_entry["description"] = registration.description
-            arguments = registration.get_arguments()
-            if arguments:
-                prompt_entry["arguments"] = arguments
-            prompts_list.append(prompt_entry)
+    for _name, registration in discovered_prompts.items():
+        prompt_entry: dict[str, Any] = {"name": registration.name}
+        if registration.title is not None:
+            prompt_entry["title"] = registration.title
+        if registration.handler is not None:
+            fn = get_handler_function(registration.handler)
+            prompt_entry["description"] = render_description(
+                registration.handler, fn, kind="prompt", fallback_name=registration.name, opt_keys=config.opt_keys
+            )
+        elif registration.description is not None:
+            prompt_entry["description"] = registration.description
+        arguments = registration.get_arguments()
+        if arguments:
+            prompt_entry["arguments"] = arguments
+        if registration.icons is not None:
+            prompt_entry.setdefault("_meta", {})["icons"] = registration.icons
+        prompts_list.append(prompt_entry)
 
     return {
         "experimental": True,

--- a/litestar_mcp/manifests.py
+++ b/litestar_mcp/manifests.py
@@ -138,7 +138,14 @@ def build_mcp_server_manifest(
     if discovered_prompts:
         for _name, registration in discovered_prompts.items():
             prompt_entry: dict[str, Any] = {"name": registration.name}
-            if registration.description is not None:
+            if registration.title is not None:
+                prompt_entry["title"] = registration.title
+            if registration.handler is not None:
+                fn = get_handler_function(registration.handler)
+                prompt_entry["description"] = render_description(
+                    registration.handler, fn, kind="prompt", fallback_name=registration.name, opt_keys=config.opt_keys
+                )
+            elif registration.description is not None:
                 prompt_entry["description"] = registration.description
             arguments = registration.get_arguments()
             if arguments:

--- a/litestar_mcp/plugin.py
+++ b/litestar_mcp/plugin.py
@@ -1,6 +1,6 @@
 """Litestar MCP Plugin implementation."""
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any
 
 from litestar import Litestar, Router
@@ -12,7 +12,7 @@ from litestar.stores.memory import MemoryStore
 
 from litestar_mcp.config import MCPConfig
 from litestar_mcp.manifests import build_agent_card, build_mcp_server_manifest, build_oauth_protected_resource
-from litestar_mcp.registry import Registry
+from litestar_mcp.registry import PromptRegistration, Registry
 from litestar_mcp.routes import MCPController
 from litestar_mcp.sessions import MCPSessionManager
 from litestar_mcp.sse import SSEManager
@@ -26,10 +26,36 @@ if TYPE_CHECKING:
 class LitestarMCP(InitPluginProtocol, CLIPlugin):
     """Litestar plugin for Model Context Protocol integration."""
 
-    def __init__(self, config: MCPConfig | None = None) -> None:
-        """Initialize the MCP plugin."""
+    def __init__(
+        self,
+        config: MCPConfig | None = None,
+        prompts: Sequence[Callable[..., Any]] | None = None,
+    ) -> None:
+        """Initialize the MCP plugin.
+
+        Args:
+            config: Plugin configuration. Defaults to ``MCPConfig()``.
+            prompts: Optional sequence of standalone prompt functions
+                decorated with ``@mcp_prompt``. These are registered
+                immediately and made available via ``prompts/list`` and
+                ``prompts/get``.
+        """
         self._config = config or MCPConfig()
         self._registry = Registry()
+        if prompts:
+            for fn in prompts:
+                metadata = get_mcp_metadata(fn) or {}
+                if metadata.get("type") != "prompt":
+                    msg = f"Function {fn!r} is not decorated with @mcp_prompt"
+                    raise ValueError(msg)
+                self._registry.register_prompt(
+                    name=metadata["name"],
+                    fn=fn,
+                    title=metadata.get("title"),
+                    description=metadata.get("description"),
+                    arguments=metadata.get("arguments"),
+                    icons=metadata.get("icons"),
+                )
         self._sse_manager = SSEManager(
             max_streams=self._config.sse_max_streams,
             max_idle_seconds=self._config.sse_max_idle_seconds,
@@ -69,6 +95,11 @@ class LitestarMCP(InitPluginProtocol, CLIPlugin):
         """Get discovered MCP resources."""
         return self._registry.resources
 
+    @property
+    def discovered_prompts(self) -> dict[str, PromptRegistration]:
+        """Get discovered MCP prompts."""
+        return self._registry.prompts
+
     def on_cli_init(self, cli: "Group") -> None:
         """Configure CLI commands for MCP operations."""
         from litestar_mcp.cli import mcp_group
@@ -91,10 +122,20 @@ class LitestarMCP(InitPluginProtocol, CLIPlugin):
                         template = metadata.get("resource_template")
                         if template is not None:
                             self._registry.register_resource_template(metadata["name"], handler, template)
+                    elif metadata["type"] == "prompt":
+                        self._registry.register_prompt_handler(
+                            metadata["name"],
+                            handler,
+                            title=metadata.get("title"),
+                            description=metadata.get("description"),
+                            arguments=metadata.get("arguments"),
+                            icons=metadata.get("icons"),
+                        )
                 elif handler.opt:
                     tool_key = self._config.opt_keys.tool
                     resource_key = self._config.opt_keys.resource
                     template_key = self._config.opt_keys.resource_template
+                    prompt_key = self._config.opt_keys.prompt
                     if tool_key in handler.opt:
                         self._registry.register_tool(handler.opt[tool_key], handler)
                     if resource_key in handler.opt:
@@ -103,6 +144,13 @@ class LitestarMCP(InitPluginProtocol, CLIPlugin):
                         opt_template = handler.opt.get(template_key)
                         if isinstance(opt_template, str):
                             self._registry.register_resource_template(resource_name, handler, opt_template)
+                    if prompt_key in handler.opt:
+                        desc_key = self._config.opt_keys.prompt_description
+                        self._registry.register_prompt_handler(
+                            handler.opt[prompt_key],
+                            handler,
+                            description=handler.opt.get(desc_key),
+                        )
 
             if getattr(handler, "route_handlers", None):
                 self._discover_mcp_routes(handler.route_handlers)  # pyright: ignore[reportAttributeAccessIssue]
@@ -146,6 +194,7 @@ class LitestarMCP(InitPluginProtocol, CLIPlugin):
                 "session_manager": Provide(provide_session_manager, sync_to_thread=False),
                 "discovered_tools": Provide(lambda: self._registry.tools, sync_to_thread=False),
                 "discovered_resources": Provide(lambda: self._registry.resources, sync_to_thread=False),
+                "discovered_prompts": Provide(lambda: self._registry.prompts, sync_to_thread=False),
             },
         }
         if self._config.guards is not None:
@@ -179,6 +228,7 @@ class LitestarMCP(InitPluginProtocol, CLIPlugin):
                 app=request.app,
                 discovered_tools=self._registry.tools,
                 discovered_resources=self._registry.resources,
+                discovered_prompts=self._registry.prompts,
             )
 
         app_config.route_handlers.extend([oauth_protected_resource, agent_card, mcp_server_manifest])

--- a/litestar_mcp/plugin.py
+++ b/litestar_mcp/plugin.py
@@ -145,11 +145,14 @@ class LitestarMCP(InitPluginProtocol, CLIPlugin):
                         if isinstance(opt_template, str):
                             self._registry.register_resource_template(resource_name, handler, opt_template)
                     if prompt_key in handler.opt:
-                        desc_key = self._config.opt_keys.prompt_description
+                        opt_keys = self._config.opt_keys
                         self._registry.register_prompt_handler(
                             handler.opt[prompt_key],
                             handler,
-                            description=handler.opt.get(desc_key),
+                            title=handler.opt.get(opt_keys.prompt_title),
+                            description=handler.opt.get(opt_keys.prompt_description),
+                            arguments=handler.opt.get(opt_keys.prompt_arguments),
+                            icons=handler.opt.get(opt_keys.prompt_icons),
                         )
 
             if getattr(handler, "route_handlers", None):

--- a/litestar_mcp/registry.py
+++ b/litestar_mcp/registry.py
@@ -51,7 +51,7 @@ def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
         # Detect end of Args section: next section header at same or lesser indent
         if stripped and not line[0].isspace():
             break
-        if stripped.endswith(":") and args_indent is not None:
+        if args_indent is not None and re.match(r"^\s+\w+:\s*$", line):
             line_indent = len(line) - len(line.lstrip())
             if line_indent <= args_indent:
                 break

--- a/litestar_mcp/registry.py
+++ b/litestar_mcp/registry.py
@@ -1,18 +1,58 @@
 """Central registry for MCP tools, resources, and prompts."""
 
+import contextlib
 import inspect
 import logging
 import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from litestar.handlers import BaseRouteHandler
 
 from litestar_mcp.sse import SSEManager
-from litestar_mcp.utils import get_mcp_metadata, parse_template
+from litestar_mcp.utils import (
+    get_handler_function,
+    get_mcp_metadata,
+    parse_template,
+    render_description,
+    should_include_handler,
+)
+
+if TYPE_CHECKING:
+    from litestar_mcp.config import MCPConfig
 
 _logger = logging.getLogger(__name__)
+
+_VALIDATION_CONTEXT_PARAMS = frozenset({
+    "request",
+    "socket",
+    "state",
+    "scope",
+    "headers",
+    "cookies",
+    "query",
+    "body",
+    "data",
+})
+"""Litestar magic-injection parameter names — excluded from MCP arg advertising.
+
+Shared with :mod:`litestar_mcp.routes` tool validation. Handler-based prompts
+also exclude these names because they're populated by the framework rather
+than passed by the MCP caller.
+"""
+
+# MCP PromptMessage content discriminator → required structural keys.
+# Per the 2025-11-25 schema, every content block carries a ``type`` and the
+# variant-specific payload keys listed here. Used by ``_normalize_prompt_result``
+# to validate dict-shaped messages without silently coercing them to text.
+_PROMPT_CONTENT_REQUIRED_KEYS: dict[str, frozenset[str]] = {
+    "text": frozenset({"text"}),
+    "image": frozenset({"data", "mimeType"}),
+    "audio": frozenset({"data", "mimeType"}),
+    "resource_link": frozenset({"uri", "name"}),
+    "resource": frozenset({"resource"}),
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,9 +136,9 @@ class PromptRegistration:
         title: Optional human-readable display name.
         description: Optional LLM-facing description.
         arguments: Explicit argument definitions. When ``None``, derived
-            from the function signature at list time (standalone prompts
-            only). Handler-based prompts return an empty argument list
-            unless arguments are set explicitly.
+            from the function signature (standalone prompts) or the
+            handler's ``signature_model`` (handler-based prompts), with
+            DI- and framework-injected parameters filtered out.
         icons: Optional list of icon objects for UI display.
     """
 
@@ -122,17 +162,26 @@ class PromptRegistration:
         """Return prompt arguments, introspecting from signature if needed.
 
         When ``arguments`` was set explicitly, returns that list unchanged.
-        Otherwise inspects the function signature and enriches each entry
-        with a ``description`` parsed from a Google-style docstring (if
-        present).
+
+        For standalone prompts, inspects ``fn.__signature__``.
+
+        For handler-based prompts, walks the handler's ``signature_model``
+        fields (the same model the tool-validation path uses), filtering out
+        DI dependencies and Litestar's magic-injected parameters
+        (``request``, ``headers``, …) so the advertised shape matches what
+        an MCP caller is expected to supply.
+
+        Both paths enrich each entry with a Google-style docstring
+        description when present.
         """
         if self.arguments is not None:
             return self.arguments
-        target = self.fn
-        if target is None:
+        if self.handler is not None:
+            return _introspect_handler_arguments(self.handler)
+        if self.fn is None:
             return []
-        sig = inspect.signature(target)
-        doc_descriptions = _parse_docstring_args(getattr(target, "__doc__", None))
+        sig = inspect.signature(self.fn)
+        doc_descriptions = _parse_docstring_args(getattr(self.fn, "__doc__", None))
         _skip = {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
         args: list[dict[str, Any]] = []
         for param_name, param in sig.parameters.items():
@@ -147,11 +196,197 @@ class PromptRegistration:
         return args
 
 
+def _introspect_handler_arguments(handler: BaseRouteHandler) -> list[dict[str, Any]]:
+    """Derive prompt arguments from a route handler's ``signature_model``.
+
+    Mirrors the partitioning used by tool-call validation in
+    :mod:`litestar_mcp.routes`: DI dependencies and framework-injected names
+    (``request``, ``headers``, ``state``, …) are excluded so the advertised
+    arguments match what callers actually supply via ``prompts/get``.
+    Descriptions are pulled from a Google-style docstring on the underlying
+    function when available.
+    """
+    import msgspec
+
+    try:
+        signature_model = handler.signature_model
+    except Exception:  # noqa: BLE001
+        return []
+    if signature_model is None:
+        return []
+    try:
+        fields = msgspec.structs.fields(signature_model)
+    except TypeError:
+        return []
+
+    di_params: set[str] = set()
+    with contextlib.suppress(AttributeError, TypeError):
+        di_params = set(handler.resolve_dependencies().keys())
+
+    fn = get_handler_function(handler)
+    doc_descriptions = _parse_docstring_args(getattr(fn, "__doc__", None))
+
+    args: list[dict[str, Any]] = []
+    for f in fields:
+        if f.name in di_params or f.name in _VALIDATION_CONTEXT_PARAMS:
+            continue
+        arg: dict[str, Any] = {"name": f.name}
+        desc = doc_descriptions.get(f.name)
+        if desc:
+            arg["description"] = desc
+        arg["required"] = f.default is msgspec.NODEFAULT and f.default_factory is msgspec.NODEFAULT
+        args.append(arg)
+    return args
+
+
+def _normalize_prompt_result(result: Any) -> list[dict[str, Any]]:
+    """Normalize a prompt's return value to a list of PromptMessage dicts.
+
+    * ``str`` → single user-role text message.
+    * ``dict`` with a valid ``role`` + ``content`` (per :data:`_PROMPT_CONTENT_REQUIRED_KEYS`)
+      is returned as-is, wrapped in a list.
+    * ``list`` items follow the same dict rules.
+    * Any other type — or any dict that doesn't look like a valid
+      ``PromptMessage`` content block — is coerced to a user-role text
+      message via ``str(item)`` with a ``warning`` log.
+
+    The variant check covers the spec's ``text`` / ``image`` / ``audio`` /
+    ``resource_link`` / ``resource`` content types: a content block missing
+    only its outer ``role`` (e.g. an unwrapped image) is still recognised
+    and not mangled into a stringified dict.
+    """
+    if isinstance(result, str):
+        return [{"role": "user", "content": {"type": "text", "text": result}}]
+    if isinstance(result, dict):
+        return [_coerce_prompt_message(result, index=None)]
+    if isinstance(result, list):
+        return [_coerce_prompt_message(item, index=i) for i, item in enumerate(result)]
+    _logger.warning("Prompt returned unexpected type %s, coercing to string", type(result).__name__)
+    return [{"role": "user", "content": {"type": "text", "text": str(result)}}]
+
+
+def _coerce_prompt_message(item: Any, *, index: int | None) -> dict[str, Any]:
+    """Coerce a single result element into a valid ``PromptMessage`` dict.
+
+    Recognises:
+      * Already-shaped messages (``role`` + ``content`` where ``content`` is
+        a valid content block or list of content blocks).
+      * Unwrapped content blocks (``type`` + variant-required keys) — wrapped
+        in a ``user``-role envelope.
+      * Anything else — stringified with a warning.
+    """
+    if not isinstance(item, dict):
+        _logger.warning(
+            "Prompt result element %sis not a dict (%s), coercing to string",
+            f"at index {index} " if index is not None else "",
+            type(item).__name__,
+        )
+        return {"role": "user", "content": {"type": "text", "text": str(item)}}
+
+    if "role" in item and "content" in item:
+        content = item["content"]
+        if _looks_like_content(content) or _looks_like_content_list(content):
+            return item
+
+    if _looks_like_content(item):
+        return {"role": "user", "content": item}
+
+    _logger.warning(
+        "Prompt result element %sdid not match PromptMessage shape (keys=%s), coercing to string",
+        f"at index {index} " if index is not None else "",
+        list(item.keys()),
+    )
+    return {"role": "user", "content": {"type": "text", "text": str(item)}}
+
+
+def _looks_like_content(value: Any) -> bool:
+    """True when ``value`` is a dict matching a known content-block variant."""
+    if not isinstance(value, dict):
+        return False
+    variant = value.get("type")
+    required = _PROMPT_CONTENT_REQUIRED_KEYS.get(variant) if isinstance(variant, str) else None
+    return required is not None and required.issubset(value.keys())
+
+
+def _looks_like_content_list(value: Any) -> bool:
+    """True when ``value`` is a non-empty list of valid content-block dicts."""
+    return isinstance(value, list) and bool(value) and all(_looks_like_content(item) for item in value)
+
+
+def resolve_prompt_description(registration: "PromptRegistration", config: "MCPConfig") -> str | None:
+    """Resolve the description string for a registered prompt.
+
+    Handler-based prompts run through ``render_description`` so opt-key
+    overrides, structured sections, and docstring fallbacks all apply
+    consistently with tools and resources. Standalone prompts use the
+    description captured at registration time (decorator value or
+    ``fn.__doc__`` fallback) — there's no opt-key plumbing on a bare fn.
+    """
+    if registration.handler is not None:
+        fn = get_handler_function(registration.handler)
+        return render_description(
+            registration.handler,
+            fn,
+            kind="prompt",
+            fallback_name=registration.name,
+            opt_keys=config.opt_keys,
+        )
+    return registration.description
+
+
+def render_prompt_entry(registration: "PromptRegistration", config: "MCPConfig") -> dict[str, Any]:
+    """Build a Prompt entry dict for ``prompts/list`` and the server manifest.
+
+    Single source of truth for the wire shape so route + manifest
+    rendering can't drift. Optional fields (``title``, ``description``,
+    ``arguments``, ``icons``) are omitted when absent rather than emitted
+    as ``null``.
+    """
+    entry: dict[str, Any] = {"name": registration.name}
+    if registration.title is not None:
+        entry["title"] = registration.title
+    description = resolve_prompt_description(registration, config)
+    if description is not None:
+        entry["description"] = description
+    arguments = registration.get_arguments()
+    if arguments:
+        entry["arguments"] = arguments
+    if registration.icons is not None:
+        entry["icons"] = registration.icons
+    return entry
+
+
+def should_include_prompt(registration: "PromptRegistration", config: "MCPConfig") -> bool:
+    """Apply ``include/exclude_operations`` and tag filters to a prompt.
+
+    Handler-based prompts get the full filter set (tags + name).
+    Standalone (fn-based) prompts skip the tag filters — they have no
+    handler tags to test — but ``include_operations`` /
+    ``exclude_operations`` name filters still apply because they select
+    by prompt name, which fn-based prompts have just like everything else.
+    """
+    if registration.handler is not None:
+        handler_tags = set(getattr(registration.handler, "tags", None) or [])
+        return should_include_handler(registration.name, handler_tags, config)
+    if config.exclude_operations and registration.name in config.exclude_operations:
+        return False
+    return not (config.include_operations and registration.name not in config.include_operations)
+
+
 class Registry:
     """Central registry for MCP tools, resources, and prompts.
 
     This class decouples metadata storage and discovery from the route handlers themselves,
     avoiding issues with __slots__ or object mutation.
+
+    Note:
+        Tools and resources are stored as bare ``BaseRouteHandler`` values
+        because every entry has a single underlying handler. Prompts use
+        :class:`PromptRegistration` instead — a prompt may originate from
+        either a standalone ``@mcp_prompt`` callable *or* a route handler,
+        so the dataclass carries the ``fn | handler`` union plus the
+        per-prompt metadata (title, description, arguments, icons) that
+        can't live on a bare callable.
     """
 
     def __init__(self) -> None:
@@ -191,6 +426,8 @@ class Registry:
             name: The tool name.
             handler: The route handler.
         """
+        if name in self._tools:
+            _logger.warning("Overwriting existing tool registration: %s", name)
         self._tools[name] = handler
 
     def register_resource(self, name: str, handler: BaseRouteHandler) -> None:
@@ -200,6 +437,8 @@ class Registry:
             name: The resource name.
             handler: The route handler.
         """
+        if name in self._resources:
+            _logger.warning("Overwriting existing resource registration: %s", name)
         self._resources[name] = handler
 
     @property
@@ -217,6 +456,8 @@ class Registry:
                 invalid templates raise :class:`ValueError`.
         """
         parse_template(template)
+        if name in self._templates:
+            _logger.warning("Overwriting existing resource template registration: %s", name)
         self._templates[name] = ResourceTemplate(name=name, template=template, handler=handler)
 
     @property

--- a/litestar_mcp/registry.py
+++ b/litestar_mcp/registry.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from litestar.exceptions import ImproperlyConfiguredException
 from litestar.handlers import BaseRouteHandler
 
 from litestar_mcp.sse import SSEManager
@@ -76,9 +77,16 @@ _GOOGLE_SECTION_HEADERS = frozenset({
 def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
     """Extract parameter descriptions from a Google-style docstring.
 
-    Parses the ``Args:`` (or ``Arguments:``, ``Params:``, ``Parameters:``)
-    section and returns ``{param_name: description}``.  Supports multi-line
-    descriptions (continuation lines indented further than the parameter line).
+    Args:
+        docstring: A Google-style docstring, or ``None``.
+
+    Returns:
+        Mapping of ``{param_name: description}`` parsed from the
+        ``Args:`` (or ``Arguments:`` / ``Params:`` / ``Parameters:``)
+        section. Continuation lines indented strictly deeper than the
+        first parameter line are appended to that parameter's description
+        — even if they contain a colon. Lines indented at the parameter
+        level that match ``name: ...`` introduce a new parameter.
     """
     if not docstring:
         return {}
@@ -87,6 +95,8 @@ def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
     result: dict[str, str] = {}
     current_name: str | None = None
     current_desc: list[str] = []
+    param_indent: int | None = None
+    param_re = re.compile(r"^(\s+)(\w+)(?:\s*\([^)]*\))?\s*:\s*(.*)$")
 
     for line in lines:
         stripped = line.strip()
@@ -95,19 +105,35 @@ def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
             continue
         if not in_args:
             continue
-        # Detect end of Args section: unindented non-empty line or known section header
+        # End of Args section: unindented non-empty line or known section header
         if stripped and not line[0].isspace():
             break
         if stripped in _GOOGLE_SECTION_HEADERS:
             break
-        # Match "param_name: description" or "param_name (type): description"
-        m = re.match(r"^\s+(\w+)(?:\s*\([^)]*\))?\s*:\s*(.*)$", line)
-        if m:
+
+        line_indent = len(line) - len(line.lstrip())
+        m = param_re.match(line)
+        # Treat the line as a continuation when:
+        #   - we have not yet seen a param (param_indent is None and m is None)
+        #   - it is indented strictly deeper than the recorded param indent
+        #     (URLs, "Default: see ...", etc. inside a param description)
+        is_continuation = (
+            current_name is not None
+            and stripped
+            and (
+                m is None
+                or (param_indent is not None and line_indent > param_indent)
+            )
+        )
+
+        if m and not is_continuation:
             if current_name is not None:
                 result[current_name] = " ".join(current_desc).strip()
-            current_name = m.group(1)
-            current_desc = [m.group(2)] if m.group(2) else []
-        elif current_name is not None and stripped:
+            current_name = m.group(2)
+            current_desc = [m.group(3)] if m.group(3) else []
+            if param_indent is None:
+                param_indent = line_indent
+        elif is_continuation:
             current_desc.append(stripped)
         elif current_name is not None and not stripped:
             # Blank line between params — skip without terminating
@@ -163,7 +189,9 @@ class PromptRegistration:
 
         When ``arguments`` was set explicitly, returns that list unchanged.
 
-        For standalone prompts, inspects ``fn.__signature__``.
+        For standalone prompts, walks ``inspect.signature(fn).parameters``
+        (which transparently consults ``fn.__signature__`` when present and
+        otherwise builds from ``fn.__code__`` / ``fn.__annotations__``).
 
         For handler-based prompts, walks the handler's ``signature_model``
         fields (the same model the tool-validation path uses), filtering out
@@ -210,7 +238,18 @@ def _introspect_handler_arguments(handler: BaseRouteHandler) -> list[dict[str, A
 
     try:
         signature_model = handler.signature_model
-    except Exception:  # noqa: BLE001
+    except (AttributeError, ImproperlyConfiguredException):
+        # Handler not yet finalized, or signature model genuinely unavailable —
+        # silent fallback is correct here (no surprise to caller).
+        return []
+    except Exception as exc:  # noqa: BLE001
+        # Anything else is unexpected; log so misconfigurations don't silently
+        # advertise zero arguments to MCP clients.
+        _logger.warning(
+            "Unexpected error reading signature_model for %r: %s — advertising no arguments",
+            getattr(handler, "handler_name", handler),
+            exc,
+        )
         return []
     if signature_model is None:
         return []
@@ -243,7 +282,9 @@ def _normalize_prompt_result(result: Any) -> list[dict[str, Any]]:
     """Normalize a prompt's return value to a list of PromptMessage dicts.
 
     * ``str`` → single user-role text message.
-    * ``dict`` with a valid ``role`` + ``content`` (per :data:`_PROMPT_CONTENT_REQUIRED_KEYS`)
+    * ``dict`` with a ``role`` key (presence-only, value not validated
+      against the spec's ``user``/``assistant`` enumeration) and a
+      ``content`` block recognised by :data:`_PROMPT_CONTENT_REQUIRED_KEYS`
       is returned as-is, wrapped in a list.
     * ``list`` items follow the same dict rules.
     * Any other type — or any dict that doesn't look like a valid
@@ -514,12 +555,12 @@ class Registry:
     ) -> None:
         """Register a route-handler-based prompt.
 
-        The handler is executed via the normal Litestar pipeline on
-        ``prompts/get``. If it returns a dict containing a ``messages``
-        key, that dict is returned directly. Otherwise the return value
-        is normalized into a messages list (str becomes a single user
-        text message, dict is wrapped as a single message, list is used
-        directly).
+        Storage only — runtime dispatch and the
+        ``messages``-passthrough vs. normalize-on-return decision live in
+        :func:`litestar_mcp.routes.handle_prompts_get`. This function
+        captures the handler reference plus any explicit overrides so the
+        registry can render ``prompts/list`` entries without executing
+        the handler.
 
         Args:
             name: Unique prompt identifier.
@@ -527,7 +568,10 @@ class Registry:
             title: Optional human-readable display name.
             description: Optional description.
             arguments: Explicit argument definitions. When ``None``,
-                handler-based prompts report an empty argument list.
+                arguments are introspected from the handler's
+                ``signature_model`` at ``prompts/list`` render time
+                (DI- and framework-injected parameters filtered out).
+                Pass ``[]`` to advertise no arguments explicitly.
             icons: Optional list of icon objects for UI display.
         """
         if name in self._prompts:

--- a/litestar_mcp/registry.py
+++ b/litestar_mcp/registry.py
@@ -65,10 +65,9 @@ def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
         elif current_name is not None and stripped:
             current_desc.append(stripped)
         elif current_name is not None and not stripped:
-            # Blank line ends current param
-            result[current_name] = " ".join(current_desc).strip()
-            current_name = None
-            current_desc = []
+            # Blank line between params — skip without terminating
+            # the current param so continuation lines are still captured.
+            pass
 
     if current_name is not None:
         result[current_name] = " ".join(current_desc).strip()

--- a/litestar_mcp/registry.py
+++ b/litestar_mcp/registry.py
@@ -24,6 +24,15 @@ class ResourceTemplate:
     handler: BaseRouteHandler
 
 
+_GOOGLE_SECTION_HEADERS = frozenset({
+    "Args:", "Arguments:", "Params:", "Parameters:",
+    "Returns:", "Return:", "Raises:", "Yields:", "Yield:",
+    "Notes:", "Note:", "Examples:", "Example:",
+    "Attributes:", "References:", "See Also:",
+    "Warnings:", "Warning:", "Todo:", "Todos:",
+})
+
+
 def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
     """Extract parameter descriptions from a Google-style docstring.
 
@@ -38,23 +47,19 @@ def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
     result: dict[str, str] = {}
     current_name: str | None = None
     current_desc: list[str] = []
-    args_indent: int | None = None
 
     for line in lines:
         stripped = line.strip()
         if stripped in ("Args:", "Arguments:", "Params:", "Parameters:"):
             in_args = True
-            args_indent = len(line) - len(line.lstrip())
             continue
         if not in_args:
             continue
-        # Detect end of Args section: next section header at same or lesser indent
+        # Detect end of Args section: unindented non-empty line or known section header
         if stripped and not line[0].isspace():
             break
-        if args_indent is not None and re.match(r"^\s+\w+:\s*$", line):
-            line_indent = len(line) - len(line.lstrip())
-            if line_indent <= args_indent:
-                break
+        if stripped in _GOOGLE_SECTION_HEADERS:
+            break
         # Match "param_name: description" or "param_name (type): description"
         m = re.match(r"^\s+(\w+)(?:\s*\([^)]*\))?\s*:\s*(.*)$", line)
         if m:

--- a/litestar_mcp/registry.py
+++ b/litestar_mcp/registry.py
@@ -1,12 +1,18 @@
-"""Central registry for MCP tools and resources."""
+"""Central registry for MCP tools, resources, and prompts."""
 
-from dataclasses import dataclass
+import inspect
+import logging
+import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 
 from litestar.handlers import BaseRouteHandler
 
 from litestar_mcp.sse import SSEManager
-from litestar_mcp.utils import parse_template
+from litestar_mcp.utils import get_mcp_metadata, parse_template
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,8 +24,127 @@ class ResourceTemplate:
     handler: BaseRouteHandler
 
 
+def _parse_docstring_args(docstring: str | None) -> dict[str, str]:
+    """Extract parameter descriptions from a Google-style docstring.
+
+    Parses the ``Args:`` (or ``Arguments:``, ``Params:``, ``Parameters:``)
+    section and returns ``{param_name: description}``.  Supports multi-line
+    descriptions (continuation lines indented further than the parameter line).
+    """
+    if not docstring:
+        return {}
+    lines = docstring.splitlines()
+    in_args = False
+    result: dict[str, str] = {}
+    current_name: str | None = None
+    current_desc: list[str] = []
+    args_indent: int | None = None
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped in ("Args:", "Arguments:", "Params:", "Parameters:"):
+            in_args = True
+            args_indent = len(line) - len(line.lstrip())
+            continue
+        if not in_args:
+            continue
+        # Detect end of Args section: next section header at same or lesser indent
+        if stripped and not line[0].isspace():
+            break
+        if stripped.endswith(":") and args_indent is not None:
+            line_indent = len(line) - len(line.lstrip())
+            if line_indent <= args_indent:
+                break
+        # Match "param_name: description" or "param_name (type): description"
+        m = re.match(r"^\s+(\w+)(?:\s*\([^)]*\))?\s*:\s*(.*)$", line)
+        if m:
+            if current_name is not None:
+                result[current_name] = " ".join(current_desc).strip()
+            current_name = m.group(1)
+            current_desc = [m.group(2)] if m.group(2) else []
+        elif current_name is not None and stripped:
+            current_desc.append(stripped)
+        elif current_name is not None and not stripped:
+            # Blank line ends current param
+            result[current_name] = " ".join(current_desc).strip()
+            current_name = None
+            current_desc = []
+
+    if current_name is not None:
+        result[current_name] = " ".join(current_desc).strip()
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class PromptRegistration:
+    """A registered MCP prompt — either a standalone callable or a route handler.
+
+    Standalone prompts are plain (async) functions decorated with
+    ``@mcp_prompt`` and passed to ``LitestarMCP(prompts=[...])``.
+
+    Handler-based prompts are Litestar route handlers discovered via the
+    ``mcp_prompt`` opt key, executed through the normal Litestar pipeline.
+
+    Attributes:
+        name: Unique prompt identifier used in ``prompts/get``.
+        fn: The callable to invoke (standalone prompt functions).
+        handler: The Litestar route handler (handler-based prompts).
+        title: Optional human-readable display name.
+        description: Optional LLM-facing description.
+        arguments: Explicit argument definitions. When ``None``, derived
+            from the function signature at list time (standalone prompts
+            only). Handler-based prompts return an empty argument list
+            unless arguments are set explicitly.
+        icons: Optional list of icon objects for UI display.
+    """
+
+    name: str
+    fn: Callable[..., Any] | None = None
+    handler: BaseRouteHandler | None = None
+    title: str | None = None
+    description: str | None = None
+    arguments: list[dict[str, Any]] | None = field(default=None, hash=False)
+    icons: list[dict[str, Any]] | None = field(default=None, hash=False)
+
+    def __post_init__(self) -> None:
+        if self.fn is not None and self.handler is not None:
+            msg = "PromptRegistration cannot have both fn and handler set"
+            raise ValueError(msg)
+        if self.fn is None and self.handler is None:
+            msg = "PromptRegistration must have either fn or handler set"
+            raise ValueError(msg)
+
+    def get_arguments(self) -> list[dict[str, Any]]:
+        """Return prompt arguments, introspecting from signature if needed.
+
+        When ``arguments`` was set explicitly, returns that list unchanged.
+        Otherwise inspects the function signature and enriches each entry
+        with a ``description`` parsed from a Google-style docstring (if
+        present).
+        """
+        if self.arguments is not None:
+            return self.arguments
+        target = self.fn
+        if target is None:
+            return []
+        sig = inspect.signature(target)
+        doc_descriptions = _parse_docstring_args(getattr(target, "__doc__", None))
+        _skip = {inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD}
+        args: list[dict[str, Any]] = []
+        for param_name, param in sig.parameters.items():
+            if param.kind in _skip or param_name == "self":
+                continue
+            arg: dict[str, Any] = {"name": param_name}
+            desc = doc_descriptions.get(param_name)
+            if desc:
+                arg["description"] = desc
+            arg["required"] = param.default is inspect.Parameter.empty
+            args.append(arg)
+        return args
+
+
 class Registry:
-    """Central registry for MCP tools and resources.
+    """Central registry for MCP tools, resources, and prompts.
 
     This class decouples metadata storage and discovery from the route handlers themselves,
     avoiding issues with __slots__ or object mutation.
@@ -30,6 +155,7 @@ class Registry:
         self._tools: dict[str, BaseRouteHandler] = {}
         self._resources: dict[str, BaseRouteHandler] = {}
         self._templates: dict[str, ResourceTemplate] = {}
+        self._prompts: dict[str, PromptRegistration] = {}
         self._sse_manager: SSEManager | None = None
 
     def set_sse_manager(self, manager: SSEManager) -> None:
@@ -89,6 +215,89 @@ class Registry:
         parse_template(template)
         self._templates[name] = ResourceTemplate(name=name, template=template, handler=handler)
 
+    @property
+    def prompts(self) -> dict[str, PromptRegistration]:
+        """Get registered prompts."""
+        return self._prompts
+
+    def register_prompt(
+        self,
+        name: str,
+        fn: Callable[..., Any],
+        *,
+        title: str | None = None,
+        description: str | None = None,
+        arguments: list[dict[str, Any]] | None = None,
+        icons: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Register a standalone prompt function.
+
+        Args:
+            name: Unique prompt identifier.
+            fn: The callable to invoke on ``prompts/get``.
+            title: Optional human-readable display name.
+            description: Optional description. Falls back to ``fn.__doc__``.
+            arguments: Explicit argument definitions. When ``None``, derived
+                from the function signature.
+            icons: Optional list of icon objects for UI display.
+        """
+        if name in self._prompts:
+            _logger.warning("Overwriting existing prompt registration: %s", name)
+        desc = description
+        if desc is None:
+            doc = getattr(fn, "__doc__", None)
+            if isinstance(doc, str) and doc.strip():
+                desc = doc.strip()
+        self._prompts[name] = PromptRegistration(
+            name=name,
+            fn=fn,
+            title=title,
+            description=desc,
+            arguments=arguments,
+            icons=icons,
+        )
+
+    def register_prompt_handler(
+        self,
+        name: str,
+        handler: BaseRouteHandler,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+        arguments: list[dict[str, Any]] | None = None,
+        icons: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Register a route-handler-based prompt.
+
+        The handler is executed via the normal Litestar pipeline on
+        ``prompts/get``. If it returns a dict containing a ``messages``
+        key, that dict is returned directly. Otherwise the return value
+        is normalized into a messages list (str becomes a single user
+        text message, dict is wrapped as a single message, list is used
+        directly).
+
+        Args:
+            name: Unique prompt identifier.
+            handler: The Litestar route handler.
+            title: Optional human-readable display name.
+            description: Optional description.
+            arguments: Explicit argument definitions. When ``None``,
+                handler-based prompts report an empty argument list.
+            icons: Optional list of icon objects for UI display.
+        """
+        if name in self._prompts:
+            _logger.warning("Overwriting existing prompt registration: %s", name)
+        metadata = get_mcp_metadata(handler) or {}
+        desc = description if description is not None else metadata.get("description")
+        self._prompts[name] = PromptRegistration(
+            name=name,
+            handler=handler,
+            title=title if title is not None else metadata.get("title"),
+            description=desc,
+            arguments=arguments if arguments is not None else metadata.get("arguments"),
+            icons=icons if icons is not None else metadata.get("icons"),
+        )
+
     async def publish_notification(
         self,
         method: str,
@@ -125,3 +334,7 @@ class Registry:
     async def notify_tools_list_changed(self) -> None:
         """Notify clients that the tool list has changed."""
         await self.publish_notification("notifications/tools/list_changed", {})
+
+    async def notify_prompts_list_changed(self) -> None:
+        """Notify clients that the prompt list has changed."""
+        await self.publish_notification("notifications/prompts/list_changed", {})

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -662,7 +662,8 @@ def build_jsonrpc_router(
 
     router.register("completion/complete", handle_completion_complete)
 
-    async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
+    async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:
+        _cursor = params.get("cursor")  # accepted per spec; pagination not yet implemented
         prompts = []
         for _name, registration in discovered_prompts.items():
             if registration.handler is not None:
@@ -672,7 +673,12 @@ def build_jsonrpc_router(
             prompt_entry: dict[str, Any] = {"name": registration.name}
             if registration.title is not None:
                 prompt_entry["title"] = registration.title
-            if registration.description is not None:
+            if registration.handler is not None:
+                fn = get_handler_function(registration.handler)
+                prompt_entry["description"] = render_description(
+                    registration.handler, fn, kind="prompt", fallback_name=registration.name, opt_keys=config.opt_keys
+                )
+            elif registration.description is not None:
                 prompt_entry["description"] = registration.description
             arguments = registration.get_arguments()
             if arguments:

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -309,6 +309,12 @@ def _normalize_prompt_result(result: Any) -> list[dict[str, Any]]:
     * ``dict`` → treated as a single message (wrapped in a list)
     * ``list`` → used directly
     * Any other type → ``str(result)`` wrapped as a user-role text message
+
+    .. warning::
+        Non-conformant return types are silently coerced to string messages
+        with a ``warning``-level log. This lenient behavior can mask bugs in
+        prompt implementations — a prompt returning the wrong type will still
+        produce a valid ``GetPromptResult`` instead of raising an error.
     """
     if isinstance(result, str):
         return [{"role": "user", "content": {"type": "text", "text": result}}]
@@ -662,14 +668,15 @@ def build_jsonrpc_router(
 
     router.register("completion/complete", handle_completion_complete)
 
-    async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:
-        _cursor = params.get("cursor")  # accepted per spec; pagination not yet implemented
+    async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
         prompts = []
         for _name, registration in discovered_prompts.items():
             if registration.handler is not None:
                 handler_tags = set(getattr(registration.handler, "tags", None) or [])
                 if not should_include_handler(registration.name, handler_tags, config):
                     continue
+            # NOTE: standalone prompts (fn-based) bypass include/exclude tag
+            # and operation filters — they have no handler or tags to filter on.
             prompt_entry: dict[str, Any] = {"name": registration.name}
             if registration.title is not None:
                 prompt_entry["title"] = registration.title

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -665,8 +665,14 @@ def build_jsonrpc_router(
 
         if registration.handler is not None:
             # Validate against the handler's declared argument shape before
-            # dispatching, so missing required args surface as INVALID_PARAMS
-            # rather than as a 500 from the framework's request parsing.
+            # dispatching. This intentionally diverges from tool-call
+            # validation: the MCP spec requires prompt arguments to be
+            # ``Record<string, string>`` (flat scalar map), whereas tools
+            # accept structured inputs validated via msgspec.convert.
+            # Pre-validating here keeps the error surface aligned with the
+            # advertised ``arguments`` list — missing required args become
+            # INVALID_PARAMS instead of a 500 emitted by the executor when
+            # the signature_model would otherwise reject the call.
             declared_args = registration.get_arguments()
             declared_names = {arg["name"] for arg in declared_args}
             missing = [
@@ -686,7 +692,11 @@ def build_jsonrpc_router(
                 raise JSONRPCErrorException(
                     JSONRPCError(
                         code=INVALID_PARAMS,
-                        message=f"Unknown prompt argument(s): {', '.join(sorted(unknown))}",
+                        message=(
+                            f"Unknown prompt argument(s): {', '.join(sorted(unknown))}. "
+                            "Prompt handlers should declare scalar arguments only; "
+                            "any 'data' body parameter on the handler is ignored by prompts/get."
+                        ),
                     )
                 )
 
@@ -698,17 +708,32 @@ def build_jsonrpc_router(
                     registration.handler, app_ref, prompt_args, request=request_context.request
                 )
             except MCPToolErrorResult as err:
-                code = INVALID_PARAMS if err.is_client_error else INTERNAL_ERROR
+                # Per JSON-RPC 2.0 INVALID_PARAMS (-32602) means specifically
+                # "invalid method parameter(s)". Reserve it for validation-shaped
+                # 4xx (400 Bad Request, 422 Unprocessable Entity); other 4xx
+                # (401/403/404/409/...) are not param-validation failures and
+                # collapse to INTERNAL_ERROR until a dedicated MCP error
+                # taxonomy is added (see issue tracker).
+                code = INVALID_PARAMS if err.status_code in {400, 422} else INTERNAL_ERROR
                 _logger.warning("Prompt handler returned error result: %s (status=%d)", prompt_name, err.status_code)
                 raise JSONRPCErrorException(
-                    JSONRPCError(code=code, message=f"Prompt execution failed: {err.content!s}")
+                    # Per JSON-RPC 2.0 §5.1, the ``data`` member carries
+                    # structured error context — preserve the handler's
+                    # rendered payload so clients can pull field paths /
+                    # error lists out programmatically instead of parsing
+                    # a stringified dict from ``message``.
+                    JSONRPCError(code=code, message="Prompt execution failed", data=err.content)
                 ) from err
             except JSONRPCErrorException:
                 raise
             except Exception as exc:
                 _logger.exception("Prompt handler execution failed: %s", prompt_name)
                 raise JSONRPCErrorException(
-                    JSONRPCError(code=INTERNAL_ERROR, message=f"Prompt execution failed: {exc!s}")
+                    JSONRPCError(
+                        code=INTERNAL_ERROR,
+                        message="Prompt execution failed",
+                        data={"error": type(exc).__name__, "detail": str(exc)},
+                    )
                 ) from exc
             handler_result: dict[str, Any]
             if isinstance(result, dict) and "messages" in result:
@@ -736,7 +761,11 @@ def build_jsonrpc_router(
             except Exception as exc:
                 _logger.exception("Prompt function execution failed: %s", prompt_name)
                 raise JSONRPCErrorException(
-                    JSONRPCError(code=INTERNAL_ERROR, message=f"Prompt execution failed: {exc!s}")
+                    JSONRPCError(
+                        code=INTERNAL_ERROR,
+                        message="Prompt execution failed",
+                        data={"error": type(exc).__name__, "detail": str(exc)},
+                    )
                 ) from exc
             messages = _normalize_prompt_result(result)
             get_result: dict[str, Any] = {"messages": messages}

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -691,7 +691,7 @@ def build_jsonrpc_router(
             if arguments:
                 prompt_entry["arguments"] = arguments
             if registration.icons is not None:
-                prompt_entry.setdefault("_meta", {})["icons"] = registration.icons
+                prompt_entry["icons"] = registration.icons
             prompts.append(prompt_entry)
         return {"prompts": prompts}
 

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -665,6 +665,10 @@ def build_jsonrpc_router(
     async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
         prompts = []
         for _name, registration in discovered_prompts.items():
+            if registration.handler is not None:
+                handler_tags = set(getattr(registration.handler, "tags", None) or [])
+                if not should_include_handler(registration.name, handler_tags, config):
+                    continue
             prompt_entry: dict[str, Any] = {"name": registration.name}
             if registration.title is not None:
                 prompt_entry["title"] = registration.title
@@ -691,6 +695,13 @@ def build_jsonrpc_router(
                 JSONRPCError(code=INVALID_PARAMS, message=f"Prompt not found: {prompt_name}")
             )
 
+        if registration.handler is not None:
+            handler_tags = set(getattr(registration.handler, "tags", None) or [])
+            if not should_include_handler(registration.name, handler_tags, config):
+                raise JSONRPCErrorException(
+                    JSONRPCError(code=INVALID_PARAMS, message=f"Prompt not found: {prompt_name}")
+                )
+
         prompt_args = params.get("arguments", {})
         if not isinstance(prompt_args, dict):
             raise JSONRPCErrorException(
@@ -716,17 +727,13 @@ def build_jsonrpc_router(
                     registration.handler, app_ref, prompt_args, request=request_context.request
                 )
             except MCPToolErrorResult as err:
-                _logger.warning("Prompt handler returned error result: %s", prompt_name)
+                code = INVALID_PARAMS if err.is_client_error else INTERNAL_ERROR
+                _logger.warning("Prompt handler returned error result: %s (status=%d)", prompt_name, err.status_code)
                 raise JSONRPCErrorException(
-                    JSONRPCError(code=INTERNAL_ERROR, message=f"Prompt execution failed: {err.content!s}")
+                    JSONRPCError(code=code, message=f"Prompt execution failed: {err.content!s}")
                 ) from err
             except JSONRPCErrorException:
                 raise
-            except TypeError as exc:
-                _logger.exception("Invalid prompt arguments for handler: %s", prompt_name)
-                raise JSONRPCErrorException(
-                    JSONRPCError(code=INVALID_PARAMS, message=f"Invalid prompt arguments: {exc!s}")
-                ) from exc
             except Exception as exc:
                 _logger.exception("Prompt handler execution failed: %s", prompt_name)
                 raise JSONRPCErrorException(

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -320,8 +320,14 @@ def _normalize_prompt_result(result: Any) -> list[dict[str, Any]]:
     if isinstance(result, list):
         coerced: list[dict[str, Any]] = []
         for i, item in enumerate(result):
-            if isinstance(item, dict):
+            if isinstance(item, dict) and "role" in item and "content" in item:
                 coerced.append(item)
+            elif isinstance(item, dict):
+                _logger.warning(
+                    "Prompt returned list with dict missing 'role'/'content' at index %d, coercing to string",
+                    i,
+                )
+                coerced.append({"role": "user", "content": {"type": "text", "text": str(item)}})
             else:
                 _logger.warning(
                     "Prompt returned list with non-dict element at index %d (%s), coercing to string",
@@ -668,7 +674,7 @@ def build_jsonrpc_router(
             if arguments:
                 prompt_entry["arguments"] = arguments
             if registration.icons is not None:
-                prompt_entry["icons"] = registration.icons
+                prompt_entry.setdefault("_meta", {})["icons"] = registration.icons
             prompts.append(prompt_entry)
         return {"prompts": prompts}
 
@@ -691,7 +697,20 @@ def build_jsonrpc_router(
                 JSONRPCError(code=INVALID_PARAMS, message="Prompt arguments must be an object")
             )
 
+        # MCP spec: prompt arguments are Record<string, string> — all values must be strings.
+        for _arg_key, _arg_val in prompt_args.items():
+            if not isinstance(_arg_val, str):
+                raise JSONRPCErrorException(
+                    JSONRPCError(
+                        code=INVALID_PARAMS,
+                        message=f"Argument '{_arg_key}' must be a string, got {type(_arg_val).__name__}",
+                    )
+                )
+
         if registration.handler is not None:
+            # Prompt handlers run through the Litestar execution pipeline
+            # (DI, middleware, guards) via execute_tool — same dispatch path
+            # as tools, reused for consistent handler execution semantics.
             try:
                 result = await execute_tool(
                     registration.handler, app_ref, prompt_args, request=request_context.request

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -25,7 +25,7 @@ from litestar.status_codes import (
 )
 
 from litestar_mcp.config import MCPConfig
-from litestar_mcp.executor import MCPToolErrorResult, execute_tool
+from litestar_mcp.executor import MCPToolErrorResult, execute_handler, execute_tool
 from litestar_mcp.jsonrpc import (
     INTERNAL_ERROR,
     INVALID_PARAMS,
@@ -38,7 +38,15 @@ from litestar_mcp.jsonrpc import (
     error_response,
     parse_request,
 )
-from litestar_mcp.registry import PromptRegistration, Registry
+from litestar_mcp.registry import (
+    _VALIDATION_CONTEXT_PARAMS,
+    PromptRegistration,
+    Registry,
+    _normalize_prompt_result,
+    render_prompt_entry,
+    resolve_prompt_description,
+    should_include_prompt,
+)
 from litestar_mcp.schema_builder import generate_schema_for_handler
 from litestar_mcp.sessions import MCPSessionManager, SessionTerminated
 from litestar_mcp.sse import StreamLimitExceeded
@@ -153,19 +161,6 @@ def _build_tool_result(value: Any, *, is_error: bool, task_id: str | None = None
     if task_id is not None:
         result["_meta"] = {"io.modelcontextprotocol/related-task": {"taskId": task_id}}
     return result
-
-
-_VALIDATION_CONTEXT_PARAMS = {
-    "request",
-    "socket",
-    "state",
-    "scope",
-    "headers",
-    "cookies",
-    "query",
-    "body",
-    "data",
-}
 
 
 def _to_pointer(name: str, msgspec_path: str) -> str:
@@ -302,50 +297,6 @@ def _validate_tool_arguments(handler: "BaseRouteHandler", tool_args: dict[str, A
     return sorted(errors, key=lambda entry: (entry["path"], entry["message"]))
 
 
-def _normalize_prompt_result(result: Any) -> list[dict[str, Any]]:
-    """Normalize a prompt's return value to a list of PromptMessage dicts.
-
-    * ``str`` → single user-role text message
-    * ``dict`` → treated as a single message (wrapped in a list)
-    * ``list`` → used directly
-    * Any other type → ``str(result)`` wrapped as a user-role text message
-
-    .. warning::
-        Non-conformant return types are silently coerced to string messages
-        with a ``warning``-level log. This lenient behavior can mask bugs in
-        prompt implementations — a prompt returning the wrong type will still
-        produce a valid ``GetPromptResult`` instead of raising an error.
-    """
-    if isinstance(result, str):
-        return [{"role": "user", "content": {"type": "text", "text": result}}]
-    if isinstance(result, dict):
-        if "role" in result and "content" in result:
-            return [result]
-        _logger.warning("Prompt returned dict missing 'role'/'content' keys: %s", list(result.keys()))
-        return [{"role": "user", "content": {"type": "text", "text": str(result)}}]
-    if isinstance(result, list):
-        coerced: list[dict[str, Any]] = []
-        for i, item in enumerate(result):
-            if isinstance(item, dict) and "role" in item and "content" in item:
-                coerced.append(item)
-            elif isinstance(item, dict):
-                _logger.warning(
-                    "Prompt returned list with dict missing 'role'/'content' at index %d, coercing to string",
-                    i,
-                )
-                coerced.append({"role": "user", "content": {"type": "text", "text": str(item)}})
-            else:
-                _logger.warning(
-                    "Prompt returned list with non-dict element at index %d (%s), coercing to string",
-                    i,
-                    type(item).__name__,
-                )
-                coerced.append({"role": "user", "content": {"type": "text", "text": str(item)}})
-        return coerced
-    _logger.warning("Prompt returned unexpected type %s, coercing to string", type(result).__name__)
-    return [{"role": "user", "content": {"type": "text", "text": str(result)}}]
-
-
 def build_jsonrpc_router(
     config: MCPConfig,
     discovered_tools: dict[str, BaseRouteHandler],
@@ -416,8 +367,13 @@ def build_jsonrpc_router(
         capabilities: dict[str, Any] = {
             "tools": {"listChanged": True},
             "resources": {"subscribe": True, "listChanged": True},
-            "prompts": {"listChanged": True},
         }
+        # Per the MCP spec a server SHOULD only advertise capabilities for
+        # primitives it actually exposes. tools/resources stay unconditional
+        # for compatibility with existing manifest behavior; prompts gate on
+        # presence to avoid claiming support when none are registered.
+        if discovered_prompts:
+            capabilities["prompts"] = {"listChanged": True}
         if task_config is not None:
             task_capabilities: dict[str, Any] = {"requests": {"tools": {"call": {}}}}
             if task_config.list_enabled:
@@ -669,30 +625,11 @@ def build_jsonrpc_router(
     router.register("completion/complete", handle_completion_complete)
 
     async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
-        prompts = []
-        for _name, registration in discovered_prompts.items():
-            if registration.handler is not None:
-                handler_tags = set(getattr(registration.handler, "tags", None) or [])
-                if not should_include_handler(registration.name, handler_tags, config):
-                    continue
-            # NOTE: standalone prompts (fn-based) bypass include/exclude tag
-            # and operation filters — they have no handler or tags to filter on.
-            prompt_entry: dict[str, Any] = {"name": registration.name}
-            if registration.title is not None:
-                prompt_entry["title"] = registration.title
-            if registration.handler is not None:
-                fn = get_handler_function(registration.handler)
-                prompt_entry["description"] = render_description(
-                    registration.handler, fn, kind="prompt", fallback_name=registration.name, opt_keys=config.opt_keys
-                )
-            elif registration.description is not None:
-                prompt_entry["description"] = registration.description
-            arguments = registration.get_arguments()
-            if arguments:
-                prompt_entry["arguments"] = arguments
-            if registration.icons is not None:
-                prompt_entry["icons"] = registration.icons
-            prompts.append(prompt_entry)
+        prompts = [
+            render_prompt_entry(registration, config)
+            for registration in discovered_prompts.values()
+            if should_include_prompt(registration, config)
+        ]
         return {"prompts": prompts}
 
     router.register("prompts/list", handle_prompts_list)
@@ -703,17 +640,10 @@ def build_jsonrpc_router(
             raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message="Missing required param: 'name'"))
 
         registration = discovered_prompts.get(prompt_name)
-        if registration is None:
+        if registration is None or not should_include_prompt(registration, config):
             raise JSONRPCErrorException(
                 JSONRPCError(code=INVALID_PARAMS, message=f"Prompt not found: {prompt_name}")
             )
-
-        if registration.handler is not None:
-            handler_tags = set(getattr(registration.handler, "tags", None) or [])
-            if not should_include_handler(registration.name, handler_tags, config):
-                raise JSONRPCErrorException(
-                    JSONRPCError(code=INVALID_PARAMS, message=f"Prompt not found: {prompt_name}")
-                )
 
         prompt_args = params.get("arguments", {})
         if not isinstance(prompt_args, dict):
@@ -722,21 +652,49 @@ def build_jsonrpc_router(
             )
 
         # MCP spec: prompt arguments are Record<string, string> — all values must be strings.
-        for _arg_key, _arg_val in prompt_args.items():
-            if not isinstance(_arg_val, str):
+        for arg_key, arg_val in prompt_args.items():
+            if not isinstance(arg_val, str):
                 raise JSONRPCErrorException(
                     JSONRPCError(
                         code=INVALID_PARAMS,
-                        message=f"Argument '{_arg_key}' must be a string, got {type(_arg_val).__name__}",
+                        message=f"Argument '{arg_key}' must be a string, got {type(arg_val).__name__}",
                     )
                 )
 
+        resolved_description = resolve_prompt_description(registration, config)
+
         if registration.handler is not None:
+            # Validate against the handler's declared argument shape before
+            # dispatching, so missing required args surface as INVALID_PARAMS
+            # rather than as a 500 from the framework's request parsing.
+            declared_args = registration.get_arguments()
+            declared_names = {arg["name"] for arg in declared_args}
+            missing = [
+                arg["name"]
+                for arg in declared_args
+                if arg.get("required") and arg["name"] not in prompt_args
+            ]
+            if missing:
+                raise JSONRPCErrorException(
+                    JSONRPCError(
+                        code=INVALID_PARAMS,
+                        message=f"Missing required prompt argument(s): {', '.join(sorted(missing))}",
+                    )
+                )
+            unknown = [name for name in prompt_args if name not in declared_names]
+            if unknown:
+                raise JSONRPCErrorException(
+                    JSONRPCError(
+                        code=INVALID_PARAMS,
+                        message=f"Unknown prompt argument(s): {', '.join(sorted(unknown))}",
+                    )
+                )
+
             # Prompt handlers run through the Litestar execution pipeline
-            # (DI, middleware, guards) via execute_tool — same dispatch path
-            # as tools, reused for consistent handler execution semantics.
+            # (DI, middleware, guards) via execute_handler — same dispatch
+            # mechanism as tools, aliased so the call site reads honestly.
             try:
-                result = await execute_tool(
+                result = await execute_handler(
                     registration.handler, app_ref, prompt_args, request=request_context.request
                 )
             except MCPToolErrorResult as err:
@@ -757,8 +715,8 @@ def build_jsonrpc_router(
                 handler_result = result
             else:
                 handler_result = {"messages": _normalize_prompt_result(result)}
-            if registration.description is not None and "description" not in handler_result:
-                handler_result["description"] = registration.description
+            if resolved_description is not None and "description" not in handler_result:
+                handler_result["description"] = resolved_description
             return handler_result
 
         if registration.fn is not None:
@@ -782,8 +740,8 @@ def build_jsonrpc_router(
                 ) from exc
             messages = _normalize_prompt_result(result)
             get_result: dict[str, Any] = {"messages": messages}
-            if registration.description is not None and "description" not in get_result:
-                get_result["description"] = registration.description
+            if resolved_description is not None and "description" not in get_result:
+                get_result["description"] = resolved_description
             return get_result
 
         raise JSONRPCErrorException(  # pragma: no cover

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -3,6 +3,8 @@
 
 import asyncio
 import contextlib
+import inspect
+import logging
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
 from typing import Any
@@ -36,7 +38,7 @@ from litestar_mcp.jsonrpc import (
     error_response,
     parse_request,
 )
-from litestar_mcp.registry import Registry
+from litestar_mcp.registry import PromptRegistration, Registry
 from litestar_mcp.schema_builder import generate_schema_for_handler
 from litestar_mcp.sessions import MCPSessionManager, SessionTerminated
 from litestar_mcp.sse import StreamLimitExceeded
@@ -48,6 +50,8 @@ from litestar_mcp.utils import (
     render_description,
     should_include_handler,
 )
+
+_logger = logging.getLogger(__name__)
 
 MCP_PROTOCOL_VERSION = "2025-11-25"
 MCP_SESSION_HEADER = "Mcp-Session-Id"
@@ -298,10 +302,43 @@ def _validate_tool_arguments(handler: "BaseRouteHandler", tool_args: dict[str, A
     return sorted(errors, key=lambda entry: (entry["path"], entry["message"]))
 
 
+def _normalize_prompt_result(result: Any) -> list[dict[str, Any]]:
+    """Normalize a prompt's return value to a list of PromptMessage dicts.
+
+    * ``str`` → single user-role text message
+    * ``dict`` → treated as a single message (wrapped in a list)
+    * ``list`` → used directly
+    * Any other type → ``str(result)`` wrapped as a user-role text message
+    """
+    if isinstance(result, str):
+        return [{"role": "user", "content": {"type": "text", "text": result}}]
+    if isinstance(result, dict):
+        if "role" in result and "content" in result:
+            return [result]
+        _logger.warning("Prompt returned dict missing 'role'/'content' keys: %s", list(result.keys()))
+        return [{"role": "user", "content": {"type": "text", "text": str(result)}}]
+    if isinstance(result, list):
+        coerced: list[dict[str, Any]] = []
+        for i, item in enumerate(result):
+            if isinstance(item, dict):
+                coerced.append(item)
+            else:
+                _logger.warning(
+                    "Prompt returned list with non-dict element at index %d (%s), coercing to string",
+                    i,
+                    type(item).__name__,
+                )
+                coerced.append({"role": "user", "content": {"type": "text", "text": str(item)}})
+        return coerced
+    _logger.warning("Prompt returned unexpected type %s, coercing to string", type(result).__name__)
+    return [{"role": "user", "content": {"type": "text", "text": str(result)}}]
+
+
 def build_jsonrpc_router(
     config: MCPConfig,
     discovered_tools: dict[str, BaseRouteHandler],
     discovered_resources: dict[str, BaseRouteHandler],
+    discovered_prompts: dict[str, PromptRegistration],
     *,
     app_ref: Any,
     request_context: RequestContext,
@@ -367,6 +404,7 @@ def build_jsonrpc_router(
         capabilities: dict[str, Any] = {
             "tools": {"listChanged": True},
             "resources": {"subscribe": True, "listChanged": True},
+            "prompts": {"listChanged": True},
         }
         if task_config is not None:
             task_capabilities: dict[str, Any] = {"requests": {"tools": {"call": {}}}}
@@ -618,6 +656,103 @@ def build_jsonrpc_router(
 
     router.register("completion/complete", handle_completion_complete)
 
+    async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
+        prompts = []
+        for _name, registration in discovered_prompts.items():
+            prompt_entry: dict[str, Any] = {"name": registration.name}
+            if registration.title is not None:
+                prompt_entry["title"] = registration.title
+            if registration.description is not None:
+                prompt_entry["description"] = registration.description
+            arguments = registration.get_arguments()
+            if arguments:
+                prompt_entry["arguments"] = arguments
+            if registration.icons is not None:
+                prompt_entry["icons"] = registration.icons
+            prompts.append(prompt_entry)
+        return {"prompts": prompts}
+
+    router.register("prompts/list", handle_prompts_list)
+
+    async def handle_prompts_get(params: dict[str, Any]) -> dict[str, Any]:
+        prompt_name = params.get("name")
+        if not prompt_name:
+            raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message="Missing required param: 'name'"))
+
+        registration = discovered_prompts.get(prompt_name)
+        if registration is None:
+            raise JSONRPCErrorException(
+                JSONRPCError(code=INVALID_PARAMS, message=f"Prompt not found: {prompt_name}")
+            )
+
+        prompt_args = params.get("arguments", {})
+        if not isinstance(prompt_args, dict):
+            raise JSONRPCErrorException(
+                JSONRPCError(code=INVALID_PARAMS, message="Prompt arguments must be an object")
+            )
+
+        if registration.handler is not None:
+            try:
+                result = await execute_tool(
+                    registration.handler, app_ref, prompt_args, request=request_context.request
+                )
+            except MCPToolErrorResult as err:
+                _logger.exception("Prompt handler execution failed: %s", prompt_name)
+                raise JSONRPCErrorException(
+                    JSONRPCError(code=INTERNAL_ERROR, message=f"Prompt execution failed: {err.content!s}")
+                ) from err
+            except JSONRPCErrorException:
+                raise
+            except TypeError as exc:
+                _logger.exception("Invalid prompt arguments for handler: %s", prompt_name)
+                raise JSONRPCErrorException(
+                    JSONRPCError(code=INVALID_PARAMS, message=f"Invalid prompt arguments: {exc!s}")
+                ) from exc
+            except Exception as exc:
+                _logger.exception("Prompt handler execution failed: %s", prompt_name)
+                raise JSONRPCErrorException(
+                    JSONRPCError(code=INTERNAL_ERROR, message=f"Prompt execution failed: {exc!s}")
+                ) from exc
+            handler_result: dict[str, Any]
+            if isinstance(result, dict) and "messages" in result:
+                handler_result = result
+            else:
+                handler_result = {"messages": _normalize_prompt_result(result)}
+            if registration.description is not None and "description" not in handler_result:
+                handler_result["description"] = registration.description
+            return handler_result
+
+        if registration.fn is not None:
+            # Validate arguments before calling to distinguish argument
+            # mismatches (INVALID_PARAMS) from TypeErrors inside the function.
+            try:
+                inspect.signature(registration.fn).bind(**prompt_args)
+            except TypeError as exc:
+                raise JSONRPCErrorException(
+                    JSONRPCError(code=INVALID_PARAMS, message=f"Invalid prompt arguments: {exc!s}")
+                ) from exc
+
+            try:
+                result = registration.fn(**prompt_args)
+                if asyncio.iscoroutine(result):
+                    result = await result
+            except Exception as exc:
+                _logger.exception("Prompt function execution failed: %s", prompt_name)
+                raise JSONRPCErrorException(
+                    JSONRPCError(code=INTERNAL_ERROR, message=f"Prompt execution failed: {exc!s}")
+                ) from exc
+            messages = _normalize_prompt_result(result)
+            get_result: dict[str, Any] = {"messages": messages}
+            if registration.description is not None and "description" not in get_result:
+                get_result["description"] = registration.description
+            return get_result
+
+        raise JSONRPCErrorException(  # pragma: no cover
+            JSONRPCError(code=INTERNAL_ERROR, message=f"Prompt has no callable: {prompt_name}")
+        )
+
+    router.register("prompts/get", handle_prompts_get)
+
     if task_store is not None:
 
         async def handle_tasks_get(params: dict[str, Any]) -> dict[str, Any]:
@@ -803,6 +938,7 @@ class MCPController(Controller):
         config: MCPConfig,
         discovered_tools: dict[str, Any],
         discovered_resources: dict[str, Any],
+        discovered_prompts: dict[str, PromptRegistration],
         registry: Registry,
         session_manager: MCPSessionManager,
         task_store: InMemoryTaskStore | None = None,
@@ -910,6 +1046,7 @@ class MCPController(Controller):
             config,
             discovered_tools,
             discovered_resources,
+            discovered_prompts,
             app_ref=request.app,
             request_context=request_context,
             task_store=task_store,

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -697,7 +697,7 @@ def build_jsonrpc_router(
                     registration.handler, app_ref, prompt_args, request=request_context.request
                 )
             except MCPToolErrorResult as err:
-                _logger.exception("Prompt handler execution failed: %s", prompt_name)
+                _logger.warning("Prompt handler returned error result: %s", prompt_name)
                 raise JSONRPCErrorException(
                     JSONRPCError(code=INTERNAL_ERROR, message=f"Prompt execution failed: {err.content!s}")
                 ) from err
@@ -734,7 +734,7 @@ def build_jsonrpc_router(
 
             try:
                 result = registration.fn(**prompt_args)
-                if asyncio.iscoroutine(result):
+                if inspect.isawaitable(result):
                     result = await result
             except Exception as exc:
                 _logger.exception("Prompt function execution failed: %s", prompt_name)

--- a/litestar_mcp/utils/__init__.py
+++ b/litestar_mcp/utils/__init__.py
@@ -3,7 +3,7 @@
 
 This module is the single home for handler-introspection helpers
 (``get_handler_function``), discovery filtering (``should_include_handler``),
-MCP metadata decorators (``@mcp_tool``, ``@mcp_resource``,
+MCP metadata decorators (``@mcp_tool``, ``@mcp_resource``, ``@mcp_prompt``,
 ``get_mcp_metadata``, ``MetadataRegistry``), LLM-facing description
 rendering (``render_description``, ``extract_description_sources``,
 ``DescriptionSources``), and the RFC 6570 Level 1 URI template helpers
@@ -279,6 +279,72 @@ def mcp_resource(
     return decorator
 
 
+def mcp_prompt(
+    name: str,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+    arguments: list[dict[str, Any]] | None = None,
+    icons: list[dict[str, Any]] | None = None,
+) -> Callable[[F], F]:
+    """Decorator to mark a callable as an MCP prompt template.
+
+    Prompt functions take keyword arguments matching the declared prompt
+    arguments and return prompt messages. The return value is normalised
+    to a list of ``PromptMessage`` dicts:
+
+    * ``str`` → single ``{"role": "user", "content": {"type": "text", "text": ...}}``
+    * ``dict`` → treated as a single message and wrapped in a list
+    * ``list[dict]`` → used directly
+    * Any other type → ``str(result)`` wrapped as a single user text message
+
+    Both sync and async callables are supported.
+
+    Args:
+        name: Unique identifier for the prompt (used in ``prompts/get``).
+        title: Optional human-readable display name for UI clients.
+        description: LLM-facing description. When omitted, ``fn.__doc__``
+            is used as the fallback during registration.
+        arguments: Optional explicit argument definitions — each entry is a
+            dict with ``name`` (required), ``description`` (optional), and
+            ``required`` (optional, defaults to introspection from the
+            function signature). When omitted the argument list is derived
+            automatically from the decorated function's signature and
+            Google-style docstring.
+        icons: Optional list of icon objects for UI display. Each entry is a
+            dict with ``src`` (URL), ``mimeType``, and optionally ``sizes``
+            per the MCP spec.
+
+    Returns:
+        Decorator function that adds MCP metadata to the callable.
+
+    Example:
+        Standalone prompt function registered via
+        ``LitestarMCP(prompts=[summarize_text])``:
+
+        ```python
+        @mcp_prompt(name="summarize", description="Summarise a document.")
+        async def summarize_text(text: str, style: str = "concise") -> str:
+            return f"Please summarise the following in a {style} style:\\n\\n{text}"
+        ```
+    """
+
+    def decorator(fn: F) -> F:
+        metadata: dict[str, Any] = {"type": "prompt", "name": name}
+        if title is not None:
+            metadata["title"] = title
+        if description is not None:
+            metadata["description"] = description
+        if arguments is not None:
+            metadata["arguments"] = arguments
+        if icons is not None:
+            metadata["icons"] = icons
+        _REGISTRY.set(fn, metadata)
+        return fn
+
+    return decorator
+
+
 def get_mcp_metadata(obj: Any) -> dict[str, Any] | None:
     """Get MCP metadata for an object if it exists.
 
@@ -295,7 +361,7 @@ def get_mcp_metadata(obj: Any) -> dict[str, Any] | None:
 # Description rendering
 # ---------------------------------------------------------------------------
 
-Kind = Literal["tool", "resource"]
+Kind = Literal["tool", "resource", "prompt"]
 
 _STRUCTURED_FIELDS: tuple[str, str, str] = ("when_to_use", "returns", "agent_instructions")
 
@@ -498,6 +564,7 @@ __all__ = (
     "get_handler_function",
     "get_mcp_metadata",
     "match_uri",
+    "mcp_prompt",
     "mcp_resource",
     "mcp_tool",
     "parse_template",

--- a/litestar_mcp/utils/__init__.py
+++ b/litestar_mcp/utils/__init__.py
@@ -306,11 +306,14 @@ def mcp_prompt(
         description: LLM-facing description. When omitted, ``fn.__doc__``
             is used as the fallback during registration.
         arguments: Optional explicit argument definitions — each entry is a
-            dict with ``name`` (required), ``description`` (optional), and
-            ``required`` (optional, defaults to introspection from the
-            function signature). When omitted the argument list is derived
-            automatically from the decorated function's signature and
-            Google-style docstring.
+            dict with ``name`` (required), and optional ``title``,
+            ``description``, and ``required`` keys. ``title`` is the
+            human-readable display name from the MCP ``BaseMetadata`` mixin
+            (a hint for UI clients; not used for matching). When omitted,
+            the argument list is derived automatically from the decorated
+            function's signature and Google-style docstring — note that
+            signature introspection cannot infer ``title``, so set it
+            explicitly when needed.
         icons: Optional list of icon objects for UI display. Each entry is a
             dict with ``src`` (URL), ``mimeType``, and optionally ``sizes``
             per the MCP spec.

--- a/tests/unit/test_native_di.py
+++ b/tests/unit/test_native_di.py
@@ -29,14 +29,18 @@ import msgspec
 import pytest
 from dishka import Provider, Scope, make_async_container, provide
 from dishka.integrations.litestar import FromDishka, inject, setup_dishka
-from litestar import Litestar, delete, get, post
+from litestar import Litestar, Response, delete, get, post
 from litestar.di import Provide
 from litestar.exceptions import NotAuthorizedException
-from litestar.status_codes import HTTP_200_OK
+from litestar.status_codes import (
+    HTTP_200_OK,
+    HTTP_422_UNPROCESSABLE_ENTITY,
+    HTTP_503_SERVICE_UNAVAILABLE,
+)
 from litestar.testing import TestClient
 
 from litestar_mcp import LitestarMCP
-from litestar_mcp.executor import execute_tool
+from litestar_mcp.executor import MCPToolErrorResult, execute_tool
 from tests.unit.conftest import get_handler_from_app
 
 if TYPE_CHECKING:
@@ -414,3 +418,46 @@ def test_guards_run_in_stdio_mode() -> None:
 
     with pytest.raises(NotAuthorizedException, match=denied_msg):
         asyncio.run(execute_tool(handler, app, {}, request=None))
+
+
+# --- MCPToolErrorResult.status_code capture ---------------------------------
+
+
+def test_execute_tool_captures_handler_4xx_status_code() -> None:
+    """Regression sentinel for the executor refactor in PR #46.
+
+    ``MCPToolErrorResult.status_code`` is the load-bearing field that the
+    prompt path (``routes.py:701``) inspects to choose between
+    ``INVALID_PARAMS`` and ``INTERNAL_ERROR``. Tools collapse 4xx/5xx to
+    ``isError=True`` so they don't exercise the field directly — without
+    this test, only the prompt path would catch a regression in
+    ``_capture_asgi_response`` status capture.
+    """
+
+    @get("/bad", opt={"mcp_tool": "bad_status"}, sync_to_thread=False)
+    def bad() -> Response[dict[str, str]]:
+        return Response(content={"error": "nope"}, status_code=HTTP_422_UNPROCESSABLE_ENTITY)
+
+    app = Litestar(route_handlers=[bad], plugins=[LitestarMCP()])
+    handler = get_handler_from_app(app, "/bad")
+
+    with pytest.raises(MCPToolErrorResult) as excinfo:
+        asyncio.run(execute_tool(handler, app, {}, request=None))
+
+    assert excinfo.value.status_code == HTTP_422_UNPROCESSABLE_ENTITY
+    assert excinfo.value.is_client_error is True
+
+
+def test_execute_tool_captures_handler_5xx_status_code() -> None:
+    @get("/down", opt={"mcp_tool": "down_status"}, sync_to_thread=False)
+    def down() -> Response[dict[str, str]]:
+        return Response(content={"error": "down"}, status_code=HTTP_503_SERVICE_UNAVAILABLE)
+
+    app = Litestar(route_handlers=[down], plugins=[LitestarMCP()])
+    handler = get_handler_from_app(app, "/down")
+
+    with pytest.raises(MCPToolErrorResult) as excinfo:
+        asyncio.run(execute_tool(handler, app, {}, request=None))
+
+    assert excinfo.value.status_code == HTTP_503_SERVICE_UNAVAILABLE
+    assert excinfo.value.is_client_error is False

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,6 +1,10 @@
 """Tests for MCP Prompts support (prompts/list and prompts/get)."""
 
+from __future__ import annotations
+
 import json
+from collections.abc import Callable
+from typing import Any
 
 import pytest
 from litestar import Litestar, get
@@ -10,6 +14,58 @@ from litestar_mcp import LitestarMCP, MCPConfig, mcp_prompt
 from litestar_mcp.registry import PromptRegistration, Registry, _parse_docstring_args
 from litestar_mcp.routes import _normalize_prompt_result
 from litestar_mcp.utils import get_mcp_metadata
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mirrors _ensure_session / _rpc pattern from test_plugin.py
+# ---------------------------------------------------------------------------
+
+
+def _ensure_session(client: TestClient[Any]) -> str:
+    key = "_mcp_session::/mcp"
+    sid = getattr(client, key, None)
+    if sid is not None:
+        return sid  # type: ignore[no-any-return]
+    init = client.post(
+        "/mcp",
+        json={
+            "jsonrpc": "2.0",
+            "id": 0,
+            "method": "initialize",
+            "params": {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "t"}},
+        },
+    )
+    sid = init.headers.get("mcp-session-id", "")
+    client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers={"Mcp-Session-Id": sid},
+    )
+    setattr(client, key, sid)
+    return str(sid)
+
+
+def _rpc(
+    client: TestClient[Any],
+    method: str,
+    params: dict[str, Any] | None = None,
+    msg_id: int = 1,
+) -> dict[str, Any]:
+    body: dict[str, Any] = {"jsonrpc": "2.0", "id": msg_id, "method": method}
+    if params is not None:
+        body["params"] = params
+    headers: dict[str, str] = {}
+    if method != "initialize":
+        sid = _ensure_session(client)
+        if sid:
+            headers["Mcp-Session-Id"] = sid
+    return client.post("/mcp", json=body, headers=headers).json()  # type: ignore[no-any-return]
+
+
+def _make_app_with_prompts(*prompt_fns: Callable[..., Any]) -> Litestar:
+    """Create a Litestar app with MCP prompts registered."""
+    plugin = LitestarMCP(config=MCPConfig(), prompts=list(prompt_fns))
+    return Litestar(route_handlers=[], plugins=[plugin])
 
 
 # ---------------------------------------------------------------------------
@@ -368,43 +424,11 @@ class TestPluginPromptRegistration:
 # ---------------------------------------------------------------------------
 
 
-def _make_app_with_prompts(*prompt_fns) -> Litestar:
-    """Create a Litestar app with MCP prompts registered."""
-    plugin = LitestarMCP(config=MCPConfig(), prompts=list(prompt_fns))
-    return Litestar(route_handlers=[], plugins=[plugin])
-
-
-def _jsonrpc(client: TestClient, method: str, params: dict | None = None, session_id: str | None = None) -> dict:
-    """Send a JSON-RPC request and return the result."""
-    body = {"jsonrpc": "2.0", "method": method, "id": 1, "params": params or {}}
-    headers = {"Content-Type": "application/json"}
-    if session_id:
-        headers["Mcp-Session-Id"] = session_id
-    resp = client.post("/mcp", json=body, headers=headers)
-    assert resp.status_code == 200
-    return resp.json()
-
-
-def _init_session(client: TestClient) -> str:
-    """Initialize an MCP session and return the session ID."""
-    resp = client.post(
-        "/mcp",
-        json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
-        headers={"Content-Type": "application/json"},
-    )
-    session_id = resp.headers.get("Mcp-Session-Id")
-    assert session_id is not None
-    # Mark initialized
-    _jsonrpc(client, "notifications/initialized", session_id=session_id)
-    return session_id
-
-
 class TestPromptsListRPC:
     def test_empty_prompts_list(self) -> None:
         app = _make_app_with_prompts()
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            data = _rpc(client, "prompts/list")
             assert data["result"]["prompts"] == []
 
     def test_lists_registered_prompts(self) -> None:
@@ -414,8 +438,7 @@ class TestPromptsListRPC:
 
         app = _make_app_with_prompts(summarize)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            data = _rpc(client, "prompts/list")
             prompts = data["result"]["prompts"]
             assert len(prompts) == 1
             assert prompts[0]["name"] == "summarize"
@@ -432,8 +455,7 @@ class TestPromptsListRPC:
 
         app = _make_app_with_prompts(fancy)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            data = _rpc(client, "prompts/list")
             prompt = data["result"]["prompts"][0]
             assert "icons" not in prompt, "icons must not be a top-level Prompt field (MCP spec)"
             assert prompt["_meta"]["icons"] == icons
@@ -451,8 +473,7 @@ class TestPromptsListRPC:
 
         app = _make_app_with_prompts(documented)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            data = _rpc(client, "prompts/list")
             args = data["result"]["prompts"][0]["arguments"]
             assert args[0]["name"] == "code"
             assert args[0]["description"] == "The source code to review."
@@ -470,8 +491,7 @@ class TestPromptsListRPC:
 
         app = _make_app_with_prompts(a, b)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            data = _rpc(client, "prompts/list")
             names = [p["name"] for p in data["result"]["prompts"]]
             assert "prompt_a" in names
             assert "prompt_b" in names
@@ -485,12 +505,10 @@ class TestPromptsGetRPC:
 
         app = _make_app_with_prompts(greet)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(
+            data = _rpc(
                 client,
                 "prompts/get",
                 params={"name": "greet", "arguments": {"name": "World"}},
-                session_id=session_id,
             )
             result = data["result"]
             assert result["description"] == "Greet someone"
@@ -505,12 +523,10 @@ class TestPromptsGetRPC:
 
         app = _make_app_with_prompts(async_greet)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(
+            data = _rpc(
                 client,
                 "prompts/get",
                 params={"name": "async_greet", "arguments": {"name": "Bob"}},
-                session_id=session_id,
             )
             assert data["result"]["messages"][0]["content"]["text"] == "Async hello, Bob!"
 
@@ -524,8 +540,7 @@ class TestPromptsGetRPC:
 
         app = _make_app_with_prompts(multi)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(client, "prompts/get", params={"name": "multi_msg"}, session_id=session_id)
+            data = _rpc(client, "prompts/get", params={"name": "multi_msg"})
             messages = data["result"]["messages"]
             assert len(messages) == 2
             assert messages[0]["role"] == "user"
@@ -534,18 +549,14 @@ class TestPromptsGetRPC:
     def test_get_nonexistent_prompt_error(self) -> None:
         app = _make_app_with_prompts()
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(
-                client, "prompts/get", params={"name": "nonexistent"}, session_id=session_id
-            )
+            data = _rpc(client, "prompts/get", params={"name": "nonexistent"})
             assert "error" in data
             assert data["error"]["code"] == -32602  # INVALID_PARAMS
 
     def test_get_prompt_missing_name_error(self) -> None:
         app = _make_app_with_prompts()
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(client, "prompts/get", params={}, session_id=session_id)
+            data = _rpc(client, "prompts/get", params={})
             assert "error" in data
             assert "Missing required param" in data["error"]["message"]
 
@@ -556,12 +567,10 @@ class TestPromptsGetRPC:
 
         app = _make_app_with_prompts(typed)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(
+            data = _rpc(
                 client,
                 "prompts/get",
                 params={"name": "typed", "arguments": []},
-                session_id=session_id,
             )
             assert "error" in data
             assert data["error"]["code"] == -32602
@@ -573,12 +582,10 @@ class TestPromptsGetRPC:
 
         app = _make_app_with_prompts(typed)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(
+            data = _rpc(
                 client,
                 "prompts/get",
                 params={"name": "typed", "arguments": {"name": 42}},
-                session_id=session_id,
             )
             assert "error" in data
             assert data["error"]["code"] == -32602
@@ -591,12 +598,10 @@ class TestPromptsGetRPC:
 
         app = _make_app_with_prompts(strict)
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(
+            data = _rpc(
                 client,
                 "prompts/get",
                 params={"name": "strict", "arguments": {"wrong_arg": "val"}},
-                session_id=session_id,
             )
             assert "error" in data
 
@@ -610,7 +615,7 @@ class TestPromptsCapability:
     def test_initialize_advertises_prompts(self) -> None:
         app = _make_app_with_prompts()
         with TestClient(app) as client:
-            data = _jsonrpc(client, "initialize")
+            data = _rpc(client, "initialize")
             capabilities = data["result"]["capabilities"]
             assert "prompts" in capabilities
             assert capabilities["prompts"]["listChanged"] is True
@@ -645,12 +650,10 @@ class TestHandlerBasedPromptDiscovery:
         plugin = LitestarMCP(config=MCPConfig())
         app = Litestar(route_handlers=[greet_handler], plugins=[plugin])
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(
+            data = _rpc(
                 client,
                 "prompts/get",
                 params={"name": "handler_greet"},
-                session_id=session_id,
             )
             result = data["result"]
             assert result["description"] == "Handler greet"
@@ -668,12 +671,10 @@ class TestHandlerBasedPromptDiscovery:
         plugin = LitestarMCP(config=MCPConfig())
         app = Litestar(route_handlers=[raw_handler], plugins=[plugin])
         with TestClient(app) as client:
-            session_id = _init_session(client)
-            data = _jsonrpc(
+            data = _rpc(
                 client,
                 "prompts/get",
                 params={"name": "raw_prompt"},
-                session_id=session_id,
             )
             result = data["result"]
             assert result["description"] == "Raw prompt"

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -286,11 +286,11 @@ class TestRegistryPrompts:
         registry.set_sse_manager(sse_manager)
 
         stream_id, stream = await sse_manager.open_stream(session_id="session1")
-        await stream.__anext__()  # Prime event
+        await anext(stream)  # Prime event
 
         await registry.notify_prompts_list_changed()
 
-        msg = await stream.__anext__()
+        msg = await anext(stream)
         data = json.loads(msg.data)
         assert data["method"] == "notifications/prompts/list_changed"
         sse_manager.disconnect(stream_id)

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -457,8 +457,8 @@ class TestPromptsListRPC:
         with TestClient(app) as client:
             data = _rpc(client, "prompts/list")
             prompt = data["result"]["prompts"][0]
-            assert "icons" not in prompt, "icons must not be a top-level Prompt field (MCP spec)"
-            assert prompt["_meta"]["icons"] == icons
+            assert prompt["icons"] == icons
+            assert "_meta" not in prompt, "icons belong at top level per MCP Icons mixin, not in _meta"
 
     def test_lists_prompt_with_docstring_arg_descriptions(self) -> None:
         @mcp_prompt(name="documented")

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -228,6 +228,17 @@ class TestParseDocstringArgs:
         """
         assert _parse_docstring_args(doc) == {"x": "First."}
 
+    def test_blank_line_between_params(self) -> None:
+        doc = """Fn.
+
+        Args:
+            x: First param.
+
+            y: Second param.
+        """
+        result = _parse_docstring_args(doc)
+        assert result == {"x": "First param.", "y": "Second param."}
+
     def test_stops_at_notes_section(self) -> None:
         doc = """Fn.
 
@@ -321,6 +332,10 @@ class TestNormalizePromptResult:
         ]
         assert _normalize_prompt_result(msgs) == msgs
 
+    def test_list_with_malformed_dict_coerced(self) -> None:
+        result = _normalize_prompt_result([{"text": "no role or content"}])
+        assert result == [{"role": "user", "content": {"type": "text", "text": "{'text': 'no role or content'}"}}]
+
     def test_other_types_stringified(self) -> None:
         result = _normalize_prompt_result(42)
         assert result == [{"role": "user", "content": {"type": "text", "text": "42"}}]
@@ -408,7 +423,7 @@ class TestPromptsListRPC:
             assert prompts[0]["description"] == "Summarize text"
             assert prompts[0]["arguments"] == [{"name": "text", "required": True}]
 
-    def test_lists_prompt_with_icons(self) -> None:
+    def test_lists_prompt_with_icons_in_meta(self) -> None:
         icons = [{"src": "https://example.com/icon.svg", "mimeType": "image/svg+xml", "sizes": ["any"]}]
 
         @mcp_prompt(name="fancy", description="Fancy prompt", icons=icons)
@@ -420,7 +435,8 @@ class TestPromptsListRPC:
             session_id = _init_session(client)
             data = _jsonrpc(client, "prompts/list", session_id=session_id)
             prompt = data["result"]["prompts"][0]
-            assert prompt["icons"] == icons
+            assert "icons" not in prompt, "icons must not be a top-level Prompt field (MCP spec)"
+            assert prompt["_meta"]["icons"] == icons
 
     def test_lists_prompt_with_docstring_arg_descriptions(self) -> None:
         @mcp_prompt(name="documented")
@@ -549,6 +565,24 @@ class TestPromptsGetRPC:
             )
             assert "error" in data
             assert data["error"]["code"] == -32602
+
+    def test_get_prompt_rejects_non_string_argument_values(self) -> None:
+        @mcp_prompt(name="typed")
+        def typed(name: str) -> str:
+            return name
+
+        app = _make_app_with_prompts(typed)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(
+                client,
+                "prompts/get",
+                params={"name": "typed", "arguments": {"name": 42}},
+                session_id=session_id,
+            )
+            assert "error" in data
+            assert data["error"]["code"] == -32602
+            assert "must be a string" in data["error"]["message"]
 
     def test_get_prompt_invalid_arguments_error(self) -> None:
         @mcp_prompt(name="strict")

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -1,0 +1,648 @@
+"""Tests for MCP Prompts support (prompts/list and prompts/get)."""
+
+import json
+
+import pytest
+from litestar import Litestar, get
+from litestar.testing import TestClient
+
+from litestar_mcp import LitestarMCP, MCPConfig, mcp_prompt
+from litestar_mcp.registry import PromptRegistration, Registry, _parse_docstring_args
+from litestar_mcp.routes import _normalize_prompt_result
+from litestar_mcp.utils import get_mcp_metadata
+
+
+# ---------------------------------------------------------------------------
+# Decorator tests
+# ---------------------------------------------------------------------------
+
+
+class TestMcpPromptDecorator:
+    def test_stores_metadata(self) -> None:
+        @mcp_prompt(name="greet", description="Greet a user")
+        def greet(name: str) -> str:
+            return f"Hello {name}"
+
+        metadata = get_mcp_metadata(greet)
+        assert metadata is not None
+        assert metadata["type"] == "prompt"
+        assert metadata["name"] == "greet"
+        assert metadata["description"] == "Greet a user"
+
+    def test_stores_title(self) -> None:
+        @mcp_prompt(name="t", title="My Title")
+        def fn() -> str:
+            return ""
+
+        metadata = get_mcp_metadata(fn)
+        assert metadata is not None
+        assert metadata["title"] == "My Title"
+
+    def test_stores_explicit_arguments(self) -> None:
+        args = [{"name": "code", "description": "The code", "required": True}]
+
+        @mcp_prompt(name="review", arguments=args)
+        def review(code: str) -> str:
+            return code
+
+        metadata = get_mcp_metadata(review)
+        assert metadata is not None
+        assert metadata["arguments"] == args
+
+    def test_stores_icons(self) -> None:
+        icons = [{"src": "https://example.com/icon.svg", "mimeType": "image/svg+xml"}]
+
+        @mcp_prompt(name="with_icons", icons=icons)
+        def fn() -> str:
+            return ""
+
+        metadata = get_mcp_metadata(fn)
+        assert metadata is not None
+        assert metadata["icons"] == icons
+
+    def test_optional_fields_omitted_when_none(self) -> None:
+        @mcp_prompt(name="bare")
+        def bare() -> str:
+            return ""
+
+        metadata = get_mcp_metadata(bare)
+        assert metadata is not None
+        assert "title" not in metadata
+        assert "description" not in metadata
+        assert "arguments" not in metadata
+        assert "icons" not in metadata
+
+
+# ---------------------------------------------------------------------------
+# PromptRegistration tests
+# ---------------------------------------------------------------------------
+
+
+class TestPromptRegistration:
+    def test_get_arguments_from_signature(self) -> None:
+        def fn(code: str, style: str = "brief") -> str:
+            return ""
+
+        reg = PromptRegistration(name="test", fn=fn)
+        args = reg.get_arguments()
+        assert len(args) == 2
+        assert args[0] == {"name": "code", "required": True}
+        assert args[1] == {"name": "style", "required": False}
+
+    def test_get_arguments_with_docstring_descriptions(self) -> None:
+        def fn(code: str, style: str = "brief") -> str:
+            """Review code.
+
+            Args:
+                code: The source code to review.
+                style: Output style (brief or detailed).
+            """
+            return ""
+
+        reg = PromptRegistration(name="test", fn=fn)
+        args = reg.get_arguments()
+        assert args[0]["description"] == "The source code to review."
+        assert args[1]["description"] == "Output style (brief or detailed)."
+
+    def test_get_arguments_explicit_overrides(self) -> None:
+        explicit = [{"name": "x", "description": "The X", "required": True}]
+        reg = PromptRegistration(name="test", fn=lambda x: x, arguments=explicit)
+        assert reg.get_arguments() == explicit
+
+    def test_get_arguments_explicit_empty(self) -> None:
+        reg = PromptRegistration(name="test", fn=lambda: "", arguments=[])
+        assert reg.get_arguments() == []
+
+    def test_icons_stored(self) -> None:
+        icons = [{"src": "https://example.com/icon.png", "mimeType": "image/png"}]
+        reg = PromptRegistration(name="test", fn=lambda: "", icons=icons)
+        assert reg.icons == icons
+
+    def test_post_init_raises_when_both_fn_and_handler(self) -> None:
+        with pytest.raises(ValueError, match="cannot have both"):
+            PromptRegistration(name="x", fn=lambda: "", handler=lambda: "")  # type: ignore[arg-type]
+
+    def test_post_init_raises_when_neither_fn_nor_handler(self) -> None:
+        with pytest.raises(ValueError, match="must have either"):
+            PromptRegistration(name="x")
+
+    def test_handler_only_returns_empty_arguments(self) -> None:
+        @get("/")
+        def handler() -> str:
+            return ""
+
+        reg = PromptRegistration(name="x", handler=handler)
+        assert reg.get_arguments() == []
+
+    def test_get_arguments_skips_var_positional_and_var_keyword(self) -> None:
+        def fn(a: str, *args: str, **kwargs: str) -> str:
+            return ""
+
+        reg = PromptRegistration(name="test", fn=fn)
+        args = reg.get_arguments()
+        names = [arg["name"] for arg in args]
+        assert "a" in names
+        assert "args" not in names
+        assert "kwargs" not in names
+
+
+# ---------------------------------------------------------------------------
+# Docstring argument parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseDocstringArgs:
+    def test_google_style(self) -> None:
+        doc = """Do something.
+
+        Args:
+            x: First param.
+            y: Second param.
+        """
+        result = _parse_docstring_args(doc)
+        assert result == {"x": "First param.", "y": "Second param."}
+
+    def test_multiline_description(self) -> None:
+        doc = """Do something.
+
+        Args:
+            code: The code to review. Can be
+                multi-line description.
+            style: Brief or detailed.
+        """
+        result = _parse_docstring_args(doc)
+        assert result["code"] == "The code to review. Can be multi-line description."
+        assert result["style"] == "Brief or detailed."
+
+    def test_with_type_annotations(self) -> None:
+        doc = """Prompt.
+
+        Args:
+            name (str): User name.
+            age (int): User age.
+        """
+        result = _parse_docstring_args(doc)
+        assert result == {"name": "User name.", "age": "User age."}
+
+    def test_empty_docstring(self) -> None:
+        assert _parse_docstring_args(None) == {}
+        assert _parse_docstring_args("") == {}
+
+    def test_no_args_section(self) -> None:
+        assert _parse_docstring_args("Just a description.") == {}
+
+    def test_stops_at_next_section(self) -> None:
+        doc = """Prompt.
+
+        Args:
+            x: A param.
+
+        Returns:
+            Something.
+        """
+        result = _parse_docstring_args(doc)
+        assert result == {"x": "A param."}
+        assert "Returns" not in result
+
+    def test_arguments_header(self) -> None:
+        doc = """Fn.
+
+        Arguments:
+            x: First.
+        """
+        assert _parse_docstring_args(doc) == {"x": "First."}
+
+    def test_params_header(self) -> None:
+        doc = """Fn.
+
+        Params:
+            x: First.
+        """
+        assert _parse_docstring_args(doc) == {"x": "First."}
+
+    def test_parameters_header(self) -> None:
+        doc = """Fn.
+
+        Parameters:
+            x: First.
+        """
+        assert _parse_docstring_args(doc) == {"x": "First."}
+
+    def test_stops_at_notes_section(self) -> None:
+        doc = """Fn.
+
+        Args:
+            x: A param.
+
+        Notes:
+            Some notes.
+        """
+        result = _parse_docstring_args(doc)
+        assert result == {"x": "A param."}
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryPrompts:
+    @pytest.fixture
+    def registry(self) -> Registry:
+        return Registry()
+
+    def test_register_prompt(self, registry: Registry) -> None:
+        def my_prompt() -> str:
+            return "hello"
+
+        registry.register_prompt("my_prompt", my_prompt, description="A prompt")
+        assert "my_prompt" in registry.prompts
+        assert registry.prompts["my_prompt"].name == "my_prompt"
+        assert registry.prompts["my_prompt"].description == "A prompt"
+        assert registry.prompts["my_prompt"].fn is my_prompt
+
+    def test_register_prompt_falls_back_to_docstring(self, registry: Registry) -> None:
+        def documented() -> str:
+            """Docstring description."""
+            return ""
+
+        registry.register_prompt("doc_prompt", documented)
+        assert registry.prompts["doc_prompt"].description == "Docstring description."
+
+    def test_register_prompt_handler(self, registry: Registry) -> None:
+        @get("/")
+        def handler() -> dict:
+            return {"messages": []}
+
+        registry.register_prompt_handler("handler_prompt", handler, description="Handler prompt")
+        assert "handler_prompt" in registry.prompts
+        assert registry.prompts["handler_prompt"].handler is handler
+
+    @pytest.mark.asyncio
+    async def test_notify_prompts_list_changed(self, registry: Registry) -> None:
+        from litestar_mcp.sse import SSEManager
+
+        sse_manager = SSEManager()
+        registry.set_sse_manager(sse_manager)
+
+        stream_id, stream = await sse_manager.open_stream(session_id="session1")
+        await stream.__anext__()  # Prime event
+
+        await registry.notify_prompts_list_changed()
+
+        msg = await stream.__anext__()
+        data = json.loads(msg.data)
+        assert data["method"] == "notifications/prompts/list_changed"
+        sse_manager.disconnect(stream_id)
+
+
+# ---------------------------------------------------------------------------
+# Result normalization tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizePromptResult:
+    def test_string_to_user_message(self) -> None:
+        result = _normalize_prompt_result("hello")
+        assert result == [{"role": "user", "content": {"type": "text", "text": "hello"}}]
+
+    def test_dict_wraps_in_list(self) -> None:
+        msg = {"role": "assistant", "content": {"type": "text", "text": "hi"}}
+        assert _normalize_prompt_result(msg) == [msg]
+
+    def test_dict_missing_keys_coerced(self) -> None:
+        result = _normalize_prompt_result({"text": "raw"})
+        assert result == [{"role": "user", "content": {"type": "text", "text": "{'text': 'raw'}"}}]
+
+    def test_list_passes_through(self) -> None:
+        msgs = [
+            {"role": "user", "content": {"type": "text", "text": "q"}},
+            {"role": "assistant", "content": {"type": "text", "text": "a"}},
+        ]
+        assert _normalize_prompt_result(msgs) == msgs
+
+    def test_other_types_stringified(self) -> None:
+        result = _normalize_prompt_result(42)
+        assert result == [{"role": "user", "content": {"type": "text", "text": "42"}}]
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration tests
+# ---------------------------------------------------------------------------
+
+
+class TestPluginPromptRegistration:
+    def test_registers_decorated_prompts(self) -> None:
+        @mcp_prompt(name="test_prompt", description="Test")
+        def my_prompt(x: str) -> str:
+            return x
+
+        plugin = LitestarMCP(prompts=[my_prompt])
+        assert "test_prompt" in plugin.discovered_prompts
+
+    def test_rejects_undecorated_functions(self) -> None:
+        def not_a_prompt() -> str:
+            return ""
+
+        with pytest.raises(ValueError, match="not decorated with @mcp_prompt"):
+            LitestarMCP(prompts=[not_a_prompt])
+
+
+# ---------------------------------------------------------------------------
+# Integration: prompts/list and prompts/get via JSON-RPC
+# ---------------------------------------------------------------------------
+
+
+def _make_app_with_prompts(*prompt_fns) -> Litestar:
+    """Create a Litestar app with MCP prompts registered."""
+    plugin = LitestarMCP(config=MCPConfig(), prompts=list(prompt_fns))
+    return Litestar(route_handlers=[], plugins=[plugin])
+
+
+def _jsonrpc(client: TestClient, method: str, params: dict | None = None, session_id: str | None = None) -> dict:
+    """Send a JSON-RPC request and return the result."""
+    body = {"jsonrpc": "2.0", "method": method, "id": 1, "params": params or {}}
+    headers = {"Content-Type": "application/json"}
+    if session_id:
+        headers["Mcp-Session-Id"] = session_id
+    resp = client.post("/mcp", json=body, headers=headers)
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def _init_session(client: TestClient) -> str:
+    """Initialize an MCP session and return the session ID."""
+    resp = client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "initialize", "id": 1, "params": {}},
+        headers={"Content-Type": "application/json"},
+    )
+    session_id = resp.headers.get("Mcp-Session-Id")
+    assert session_id is not None
+    # Mark initialized
+    _jsonrpc(client, "notifications/initialized", session_id=session_id)
+    return session_id
+
+
+class TestPromptsListRPC:
+    def test_empty_prompts_list(self) -> None:
+        app = _make_app_with_prompts()
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            assert data["result"]["prompts"] == []
+
+    def test_lists_registered_prompts(self) -> None:
+        @mcp_prompt(name="summarize", title="Summarize", description="Summarize text")
+        def summarize(text: str) -> str:
+            return f"Summary of: {text}"
+
+        app = _make_app_with_prompts(summarize)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            prompts = data["result"]["prompts"]
+            assert len(prompts) == 1
+            assert prompts[0]["name"] == "summarize"
+            assert prompts[0]["title"] == "Summarize"
+            assert prompts[0]["description"] == "Summarize text"
+            assert prompts[0]["arguments"] == [{"name": "text", "required": True}]
+
+    def test_lists_prompt_with_icons(self) -> None:
+        icons = [{"src": "https://example.com/icon.svg", "mimeType": "image/svg+xml", "sizes": ["any"]}]
+
+        @mcp_prompt(name="fancy", description="Fancy prompt", icons=icons)
+        def fancy() -> str:
+            return ""
+
+        app = _make_app_with_prompts(fancy)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            prompt = data["result"]["prompts"][0]
+            assert prompt["icons"] == icons
+
+    def test_lists_prompt_with_docstring_arg_descriptions(self) -> None:
+        @mcp_prompt(name="documented")
+        def documented(code: str, lang: str = "python") -> str:
+            """Review code.
+
+            Args:
+                code: The source code to review.
+                lang: Programming language.
+            """
+            return code
+
+        app = _make_app_with_prompts(documented)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            args = data["result"]["prompts"][0]["arguments"]
+            assert args[0]["name"] == "code"
+            assert args[0]["description"] == "The source code to review."
+            assert args[1]["name"] == "lang"
+            assert args[1]["description"] == "Programming language."
+
+    def test_lists_multiple_prompts(self) -> None:
+        @mcp_prompt(name="prompt_a")
+        def a() -> str:
+            return ""
+
+        @mcp_prompt(name="prompt_b")
+        def b(x: str = "default") -> str:
+            return x
+
+        app = _make_app_with_prompts(a, b)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(client, "prompts/list", session_id=session_id)
+            names = [p["name"] for p in data["result"]["prompts"]]
+            assert "prompt_a" in names
+            assert "prompt_b" in names
+
+
+class TestPromptsGetRPC:
+    def test_get_sync_prompt(self) -> None:
+        @mcp_prompt(name="greet", description="Greet someone")
+        def greet(name: str) -> str:
+            return f"Hello, {name}!"
+
+        app = _make_app_with_prompts(greet)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(
+                client,
+                "prompts/get",
+                params={"name": "greet", "arguments": {"name": "World"}},
+                session_id=session_id,
+            )
+            result = data["result"]
+            assert result["description"] == "Greet someone"
+            assert len(result["messages"]) == 1
+            assert result["messages"][0]["role"] == "user"
+            assert result["messages"][0]["content"]["text"] == "Hello, World!"
+
+    def test_get_async_prompt(self) -> None:
+        @mcp_prompt(name="async_greet")
+        async def async_greet(name: str) -> str:
+            return f"Async hello, {name}!"
+
+        app = _make_app_with_prompts(async_greet)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(
+                client,
+                "prompts/get",
+                params={"name": "async_greet", "arguments": {"name": "Bob"}},
+                session_id=session_id,
+            )
+            assert data["result"]["messages"][0]["content"]["text"] == "Async hello, Bob!"
+
+    def test_get_prompt_returns_messages_list(self) -> None:
+        @mcp_prompt(name="multi_msg")
+        def multi() -> list:
+            return [
+                {"role": "user", "content": {"type": "text", "text": "Question"}},
+                {"role": "assistant", "content": {"type": "text", "text": "Answer"}},
+            ]
+
+        app = _make_app_with_prompts(multi)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(client, "prompts/get", params={"name": "multi_msg"}, session_id=session_id)
+            messages = data["result"]["messages"]
+            assert len(messages) == 2
+            assert messages[0]["role"] == "user"
+            assert messages[1]["role"] == "assistant"
+
+    def test_get_nonexistent_prompt_error(self) -> None:
+        app = _make_app_with_prompts()
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(
+                client, "prompts/get", params={"name": "nonexistent"}, session_id=session_id
+            )
+            assert "error" in data
+            assert data["error"]["code"] == -32602  # INVALID_PARAMS
+
+    def test_get_prompt_missing_name_error(self) -> None:
+        app = _make_app_with_prompts()
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(client, "prompts/get", params={}, session_id=session_id)
+            assert "error" in data
+            assert "Missing required param" in data["error"]["message"]
+
+    def test_get_prompt_arguments_must_be_object(self) -> None:
+        @mcp_prompt(name="typed")
+        def typed(name: str) -> str:
+            return name
+
+        app = _make_app_with_prompts(typed)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(
+                client,
+                "prompts/get",
+                params={"name": "typed", "arguments": []},
+                session_id=session_id,
+            )
+            assert "error" in data
+            assert data["error"]["code"] == -32602
+
+    def test_get_prompt_invalid_arguments_error(self) -> None:
+        @mcp_prompt(name="strict")
+        def strict(required_arg: str) -> str:
+            return required_arg
+
+        app = _make_app_with_prompts(strict)
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(
+                client,
+                "prompts/get",
+                params={"name": "strict", "arguments": {"wrong_arg": "val"}},
+                session_id=session_id,
+            )
+            assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# Capability advertisement
+# ---------------------------------------------------------------------------
+
+
+class TestPromptsCapability:
+    def test_initialize_advertises_prompts(self) -> None:
+        app = _make_app_with_prompts()
+        with TestClient(app) as client:
+            data = _jsonrpc(client, "initialize")
+            capabilities = data["result"]["capabilities"]
+            assert "prompts" in capabilities
+            assert capabilities["prompts"]["listChanged"] is True
+
+
+# ---------------------------------------------------------------------------
+# Handler-based prompt discovery via opt key
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerBasedPromptDiscovery:
+    def test_opt_key_prompt_discovered(self) -> None:
+        @get("/review", mcp_prompt="code_review", mcp_prompt_description="Review code")
+        async def review_handler(code: str) -> dict:
+            return {
+                "messages": [{"role": "user", "content": {"type": "text", "text": f"Review: {code}"}}]
+            }
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[review_handler], plugins=[plugin])
+        assert "code_review" in plugin.discovered_prompts
+
+    def test_handler_prompt_get_e2e_dict_response(self) -> None:
+        """Handler returns {"messages": ...} — passed through directly."""
+
+        @get("/greet-handler", mcp_prompt="handler_greet", mcp_prompt_description="Handler greet")
+        async def greet_handler() -> dict:
+            return {
+                "messages": [{"role": "assistant", "content": {"type": "text", "text": "Handler says hi"}}]
+            }
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[greet_handler], plugins=[plugin])
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(
+                client,
+                "prompts/get",
+                params={"name": "handler_greet"},
+                session_id=session_id,
+            )
+            result = data["result"]
+            assert result["description"] == "Handler greet"
+            assert len(result["messages"]) == 1
+            assert result["messages"][0]["role"] == "assistant"
+            assert result["messages"][0]["content"]["text"] == "Handler says hi"
+
+    def test_handler_prompt_get_e2e_normalized_response(self) -> None:
+        """Handler returns dict without 'messages' key — normalized via _normalize_prompt_result."""
+
+        @get("/raw-handler", mcp_prompt="raw_prompt", mcp_prompt_description="Raw prompt")
+        async def raw_handler() -> dict:
+            return {"role": "user", "content": {"type": "text", "text": "Normalized"}}
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[raw_handler], plugins=[plugin])
+        with TestClient(app) as client:
+            session_id = _init_session(client)
+            data = _jsonrpc(
+                client,
+                "prompts/get",
+                params={"name": "raw_prompt"},
+                session_id=session_id,
+            )
+            result = data["result"]
+            assert result["description"] == "Raw prompt"
+            assert result["messages"] == [
+                {"role": "user", "content": {"type": "text", "text": "Normalized"}}
+            ]

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -7,14 +7,18 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
-from litestar import Litestar, get
+from litestar import Litestar, Response, get
+from litestar.status_codes import HTTP_400_BAD_REQUEST, HTTP_500_INTERNAL_SERVER_ERROR
 from litestar.testing import TestClient
 
 from litestar_mcp import LitestarMCP, MCPConfig, mcp_prompt
-from litestar_mcp.registry import PromptRegistration, Registry, _parse_docstring_args
-from litestar_mcp.routes import _normalize_prompt_result
+from litestar_mcp.registry import (
+    PromptRegistration,
+    Registry,
+    _normalize_prompt_result,
+    _parse_docstring_args,
+)
 from litestar_mcp.utils import get_mcp_metadata
-
 
 # ---------------------------------------------------------------------------
 # Helpers — mirrors _ensure_session / _rpc pattern from test_plugin.py
@@ -182,13 +186,39 @@ class TestPromptRegistration:
         with pytest.raises(ValueError, match="must have either"):
             PromptRegistration(name="x")
 
-    def test_handler_only_returns_empty_arguments(self) -> None:
+    def test_handler_with_no_params_returns_empty_arguments(self) -> None:
         @get("/")
         def handler() -> str:
             return ""
 
         reg = PromptRegistration(name="x", handler=handler)
         assert reg.get_arguments() == []
+
+    def test_handler_arguments_introspected_from_signature_model(self) -> None:
+        """Handler-based prompts derive arguments from the handler's
+        ``signature_model`` so ``prompts/list`` advertises the real shape
+        instead of an empty list.
+        """
+
+        @get("/x", mcp_prompt="x_prompt")
+        def x_handler(code: str, style: str = "brief") -> str:
+            """Review handler.
+
+            Args:
+                code: The source code.
+                style: Output style.
+            """
+            return ""
+
+        plugin = LitestarMCP(config=MCPConfig())
+        Litestar(route_handlers=[x_handler], plugins=[plugin])
+        args = plugin.discovered_prompts["x_prompt"].get_arguments()
+        names_required = [(a["name"], a.get("required")) for a in args]
+        assert ("code", True) in names_required
+        assert ("style", False) in names_required
+        descriptions = {a["name"]: a.get("description") for a in args}
+        assert descriptions["code"] == "The source code."
+        assert descriptions["style"] == "Output style."
 
     def test_get_arguments_skips_var_positional_and_var_keyword(self) -> None:
         def fn(a: str, *args: str, **kwargs: str) -> str:
@@ -612,13 +642,24 @@ class TestPromptsGetRPC:
 
 
 class TestPromptsCapability:
-    def test_initialize_advertises_prompts(self) -> None:
-        app = _make_app_with_prompts()
+    def test_initialize_advertises_prompts_when_registered(self) -> None:
+        @mcp_prompt(name="any_prompt")
+        def any_prompt() -> str:
+            return ""
+
+        app = _make_app_with_prompts(any_prompt)
         with TestClient(app) as client:
             data = _rpc(client, "initialize")
             capabilities = data["result"]["capabilities"]
             assert "prompts" in capabilities
             assert capabilities["prompts"]["listChanged"] is True
+
+    def test_initialize_omits_prompts_capability_when_none_registered(self) -> None:
+        """Per MCP spec, only advertise capabilities the server provides."""
+        app = _make_app_with_prompts()
+        with TestClient(app) as client:
+            data = _rpc(client, "initialize")
+            assert "prompts" not in data["result"]["capabilities"]
 
 
 # ---------------------------------------------------------------------------
@@ -635,7 +676,7 @@ class TestHandlerBasedPromptDiscovery:
             }
 
         plugin = LitestarMCP(config=MCPConfig())
-        app = Litestar(route_handlers=[review_handler], plugins=[plugin])
+        Litestar(route_handlers=[review_handler], plugins=[plugin])
         assert "code_review" in plugin.discovered_prompts
 
     def test_handler_prompt_get_e2e_dict_response(self) -> None:
@@ -681,3 +722,245 @@ class TestHandlerBasedPromptDiscovery:
             assert result["messages"] == [
                 {"role": "user", "content": {"type": "text", "text": "Normalized"}}
             ]
+
+    def test_handler_prompt_missing_required_arg_returns_invalid_params(self) -> None:
+        """MCP spec: missing a required prompt argument MUST surface as INVALID_PARAMS."""
+
+        @get("/needs-code", mcp_prompt="needs_code", mcp_prompt_description="Needs code")
+        async def needs_code(code: str) -> dict:
+            return {
+                "messages": [{"role": "user", "content": {"type": "text", "text": code}}]
+            }
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[needs_code], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/get", params={"name": "needs_code", "arguments": {}})
+            assert "error" in data
+            assert data["error"]["code"] == -32602
+            assert "code" in data["error"]["message"]
+
+    def test_handler_prompt_unknown_arg_returns_invalid_params(self) -> None:
+        """Unknown prompt argument names MUST surface as INVALID_PARAMS."""
+
+        @get("/typed-handler", mcp_prompt="typed_handler", mcp_prompt_description="Typed handler")
+        async def typed_handler(name: str) -> dict:
+            return {
+                "messages": [{"role": "user", "content": {"type": "text", "text": name}}]
+            }
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[typed_handler], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(
+                client,
+                "prompts/get",
+                params={"name": "typed_handler", "arguments": {"name": "x", "wrong": "y"}},
+            )
+            assert "error" in data
+            assert data["error"]["code"] == -32602
+            assert "wrong" in data["error"]["message"]
+
+
+# ---------------------------------------------------------------------------
+# Spec coverage: _meta echo on prompts/get
+# ---------------------------------------------------------------------------
+
+
+class TestPromptsGetMetaEcho:
+    def test_handler_prompt_meta_passthrough(self) -> None:
+        """Handler-set _meta on the prompt result is preserved on the wire.
+
+        MCP spec allows servers to attach ``_meta`` to ``GetPromptResult``;
+        when a prompt handler explicitly returns it, the route layer must
+        not strip it.
+        """
+
+        @get("/meta-handler", mcp_prompt="meta_prompt", mcp_prompt_description="Meta prompt")
+        async def meta_handler() -> dict:
+            return {
+                "messages": [{"role": "user", "content": {"type": "text", "text": "hi"}}],
+                "_meta": {"trace_id": "abc-123"},
+            }
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[meta_handler], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/get", params={"name": "meta_prompt"})
+            result = data["result"]
+            assert result["_meta"] == {"trace_id": "abc-123"}
+
+
+# ---------------------------------------------------------------------------
+# Opt-key parity: title / arguments / icons
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerPromptOptKeys:
+    def test_opt_keys_carry_title_arguments_icons(self) -> None:
+        explicit_args = [{"name": "topic", "description": "Topic to summarise", "required": True}]
+        icons = [{"src": "https://example.com/icon.svg", "mimeType": "image/svg+xml"}]
+
+        @get(
+            "/summarise",
+            mcp_prompt="opt_summarise",
+            mcp_prompt_title="Summarise",
+            mcp_prompt_description="Summarise a topic",
+            mcp_prompt_arguments=explicit_args,
+            mcp_prompt_icons=icons,
+        )
+        async def summarise(topic: str) -> dict:
+            return {"messages": [{"role": "user", "content": {"type": "text", "text": topic}}]}
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[summarise], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/list")
+            entry = next(p for p in data["result"]["prompts"] if p["name"] == "opt_summarise")
+            assert entry["title"] == "Summarise"
+            assert entry["arguments"] == explicit_args
+            assert entry["icons"] == icons
+
+
+# ---------------------------------------------------------------------------
+# Spec coverage: PromptArgument.title pass-through (BaseMetadata mixin)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptArgumentTitle:
+    def test_explicit_argument_title_passes_through(self) -> None:
+        """Per MCP spec, ``PromptArgument`` carries an optional ``title`` from
+        the ``BaseMetadata`` mixin. It cannot be derived from a function
+        signature; explicit ``arguments=[...]`` carries it through verbatim.
+        """
+        explicit = [
+            {"name": "code", "title": "Source Code", "description": "The code", "required": True},
+        ]
+
+        @mcp_prompt(name="titled", arguments=explicit)
+        def titled(code: str) -> str:
+            return code
+
+        app = _make_app_with_prompts(titled)
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/list")
+            entry = next(p for p in data["result"]["prompts"] if p["name"] == "titled")
+            assert entry["arguments"] == explicit
+            assert entry["arguments"][0]["title"] == "Source Code"
+
+
+# ---------------------------------------------------------------------------
+# Error-mapping coverage: handler 4xx vs 5xx, fn exception INTERNAL_ERROR
+# ---------------------------------------------------------------------------
+
+
+class TestPromptErrorMapping:
+    def test_standalone_fn_exception_maps_to_internal_error(self) -> None:
+        """Plain exceptions inside a standalone prompt fn surface as -32603."""
+
+        @mcp_prompt(name="boom")
+        def boom() -> str:
+            msg = "kaboom"
+            raise RuntimeError(msg)
+
+        app = _make_app_with_prompts(boom)
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/get", params={"name": "boom"})
+            assert "error" in data
+            assert data["error"]["code"] == -32603  # INTERNAL_ERROR
+            assert "kaboom" in data["error"]["message"]
+
+    def test_handler_4xx_maps_to_invalid_params(self) -> None:
+        """Handler returning a 4xx Response surfaces as -32602 (INVALID_PARAMS).
+
+        ``MCPToolErrorResult.is_client_error`` keys off the captured HTTP
+        status; the route layer maps that to JSON-RPC ``INVALID_PARAMS``.
+        """
+
+        @get("/bad-handler", mcp_prompt="bad_4xx", mcp_prompt_description="Bad handler")
+        async def bad_handler() -> Response[dict[str, str]]:
+            return Response(content={"error": "bad input"}, status_code=HTTP_400_BAD_REQUEST)
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[bad_handler], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/get", params={"name": "bad_4xx"})
+            assert "error" in data
+            assert data["error"]["code"] == -32602  # INVALID_PARAMS
+
+    def test_handler_5xx_maps_to_internal_error(self) -> None:
+        """Handler returning a 5xx Response surfaces as -32603 (INTERNAL_ERROR)."""
+
+        @get("/boom-handler", mcp_prompt="bad_5xx", mcp_prompt_description="Boom handler")
+        async def boom_handler() -> Response[dict[str, str]]:
+            return Response(content={"error": "boom"}, status_code=HTTP_500_INTERNAL_SERVER_ERROR)
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[boom_handler], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/get", params={"name": "bad_5xx"})
+            assert "error" in data
+            assert data["error"]["code"] == -32603
+
+
+# ---------------------------------------------------------------------------
+# Filter coverage: prompts respect include/exclude_operations + tags
+# ---------------------------------------------------------------------------
+
+
+class TestPromptFiltering:
+    def test_handler_prompt_excluded_by_operations_hidden_from_list(self) -> None:
+        @get("/secret", mcp_prompt="secret_prompt", mcp_prompt_description="Secret")
+        async def secret() -> dict:
+            return {"messages": [{"role": "user", "content": {"type": "text", "text": "x"}}]}
+
+        plugin = LitestarMCP(config=MCPConfig(exclude_operations=["secret_prompt"]))
+        app = Litestar(route_handlers=[secret], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/list")
+            names = [p["name"] for p in data["result"]["prompts"]]
+            assert "secret_prompt" not in names
+
+    def test_handler_prompt_excluded_by_operations_returns_invalid_params(self) -> None:
+        @get("/secret-get", mcp_prompt="secret_get", mcp_prompt_description="Secret")
+        async def secret_get() -> dict:
+            return {"messages": [{"role": "user", "content": {"type": "text", "text": "x"}}]}
+
+        plugin = LitestarMCP(config=MCPConfig(exclude_operations=["secret_get"]))
+        app = Litestar(route_handlers=[secret_get], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/get", params={"name": "secret_get"})
+            assert "error" in data
+            assert data["error"]["code"] == -32602
+            assert "not found" in data["error"]["message"].lower()
+
+    def test_handler_prompt_excluded_by_tags(self) -> None:
+        @get("/tagged", mcp_prompt="tagged_prompt", mcp_prompt_description="Tagged", tags=["internal"])
+        async def tagged() -> dict:
+            return {"messages": [{"role": "user", "content": {"type": "text", "text": "x"}}]}
+
+        plugin = LitestarMCP(config=MCPConfig(exclude_tags=["internal"]))
+        app = Litestar(route_handlers=[tagged], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/list")
+            names = [p["name"] for p in data["result"]["prompts"]]
+            assert "tagged_prompt" not in names
+
+    def test_standalone_prompt_excluded_by_operations(self) -> None:
+        """fn-based prompts are subject to name-based filters too."""
+
+        @mcp_prompt(name="hidden_fn")
+        def hidden_fn() -> str:
+            return ""
+
+        plugin = LitestarMCP(
+            config=MCPConfig(exclude_operations=["hidden_fn"]),
+            prompts=[hidden_fn],
+        )
+        app = Litestar(route_handlers=[], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/list")
+            assert data["result"]["prompts"] == []
+            data = _rpc(client, "prompts/get", params={"name": "hidden_fn"})
+            assert "error" in data
+            assert data["error"]["code"] == -32602

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -231,6 +231,65 @@ class TestPromptRegistration:
         assert "args" not in names
         assert "kwargs" not in names
 
+    def test_handler_request_param_filtered_from_arguments(self) -> None:
+        """Litestar's magic-injected ``request`` must not leak into prompts/list."""
+        from litestar import Request
+
+        @get("/with-request", mcp_prompt="needs_req")
+        async def needs_req(text: str, request: Request) -> str:  # noqa: ARG001
+            return text
+
+        plugin = LitestarMCP(config=MCPConfig())
+        Litestar(route_handlers=[needs_req], plugins=[plugin])
+        args = plugin.discovered_prompts["needs_req"].get_arguments()
+        names = [a["name"] for a in args]
+        assert "text" in names
+        assert "request" not in names, "magic-injected param leaked into MCP arg list"
+
+    def test_handler_headers_param_filtered_from_arguments(self) -> None:
+        """``headers`` is a framework-injected name and must be filtered."""
+
+        @get("/with-headers", mcp_prompt="needs_hdr")
+        async def needs_hdr(text: str, headers: dict[str, str]) -> str:  # noqa: ARG001
+            return text
+
+        plugin = LitestarMCP(config=MCPConfig())
+        Litestar(route_handlers=[needs_hdr], plugins=[plugin])
+        names = [a["name"] for a in plugin.discovered_prompts["needs_hdr"].get_arguments()]
+        assert "headers" not in names
+
+    def test_handler_di_dependency_filtered_from_arguments(self) -> None:
+        """Provide() dependencies must be excluded from prompts/list."""
+        from litestar.di import Provide
+
+        async def supply_secret() -> str:
+            return "shh"
+
+        @get("/with-di", mcp_prompt="needs_di", dependencies={"secret": Provide(supply_secret)})
+        async def needs_di(text: str, secret: str) -> str:  # noqa: ARG001
+            return text
+
+        plugin = LitestarMCP(config=MCPConfig())
+        Litestar(route_handlers=[needs_di], plugins=[plugin])
+        names = [a["name"] for a in plugin.discovered_prompts["needs_di"].get_arguments()]
+        assert "text" in names
+        assert "secret" not in names, "DI dependency leaked into advertised arguments"
+
+    def test_introspect_handler_resolve_dependencies_failure_is_silent(self) -> None:
+        """resolve_dependencies() raising AttributeError/TypeError must not
+        propagate — empty di_params is the safe fallback."""
+        from types import SimpleNamespace
+
+        from litestar_mcp.registry import _introspect_handler_arguments
+
+        # Stub handler whose resolve_dependencies blows up. We still want
+        # introspection to succeed against a None signature_model.
+        stub = SimpleNamespace(
+            signature_model=None,
+            resolve_dependencies=lambda: (_ for _ in ()).throw(AttributeError("nope")),
+        )
+        assert _introspect_handler_arguments(stub) == []  # type: ignore[arg-type]
+
 
 # ---------------------------------------------------------------------------
 # Docstring argument parsing tests
@@ -337,6 +396,53 @@ class TestParseDocstringArgs:
         result = _parse_docstring_args(doc)
         assert result == {"x": "A param."}
 
+    def test_continuation_line_with_colon_not_treated_as_param(self) -> None:
+        """I1 regression: a continuation line containing ``:`` (URL,
+        ``Default: foo``, ``e.g.: bar``) must extend the current
+        parameter's description, not introduce a phantom parameter."""
+        doc = """Fn.
+
+        Args:
+            code: The code to review.
+                Default: see config above.
+                See also: https://example.com/docs
+            style: Output style.
+        """
+        result = _parse_docstring_args(doc)
+        assert result == {
+            "code": (
+                "The code to review. Default: see config above. "
+                "See also: https://example.com/docs"
+            ),
+            "style": "Output style.",
+        }
+
+    def test_empty_args_section(self) -> None:
+        """Args: header followed immediately by another section returns {}."""
+        doc = """Fn.
+
+        Args:
+
+        Returns:
+            Nothing.
+        """
+        assert _parse_docstring_args(doc) == {}
+
+    def test_args_section_terminated_by_unindented_text(self) -> None:
+        """Unindented non-empty line ends the Args section."""
+        doc = "Fn.\n\n        Args:\n            x: First.\nAfter args block.\n"
+        assert _parse_docstring_args(doc) == {"x": "First."}
+
+    def test_line_without_colon_appended_to_previous_param(self) -> None:
+        """Indented line w/o colon = continuation, not a new param."""
+        doc = """Fn.
+
+        Args:
+            x: First param.
+                additional notes without colon
+        """
+        assert _parse_docstring_args(doc) == {"x": "First param. additional notes without colon"}
+
 
 # ---------------------------------------------------------------------------
 # Registry tests
@@ -425,6 +531,57 @@ class TestNormalizePromptResult:
     def test_other_types_stringified(self) -> None:
         result = _normalize_prompt_result(42)
         assert result == [{"role": "user", "content": {"type": "text", "text": "42"}}]
+
+    def test_image_content_block_passes_through(self) -> None:
+        """Per MCP spec a message w/ image content survives normalization."""
+        msg = {
+            "role": "user",
+            "content": {"type": "image", "data": "Zg==", "mimeType": "image/png"},
+        }
+        assert _normalize_prompt_result(msg) == [msg]
+
+    def test_audio_content_block_passes_through(self) -> None:
+        msg = {
+            "role": "user",
+            "content": {"type": "audio", "data": "Zg==", "mimeType": "audio/wav"},
+        }
+        assert _normalize_prompt_result(msg) == [msg]
+
+    def test_resource_link_content_block_passes_through(self) -> None:
+        msg = {
+            "role": "user",
+            "content": {"type": "resource_link", "uri": "file://x", "name": "x"},
+        }
+        assert _normalize_prompt_result(msg) == [msg]
+
+    def test_resource_content_block_passes_through(self) -> None:
+        msg = {
+            "role": "user",
+            "content": {"type": "resource", "resource": {"uri": "file://x", "text": "y"}},
+        }
+        assert _normalize_prompt_result(msg) == [msg]
+
+    def test_unwrapped_image_block_wrapped_in_user_envelope(self) -> None:
+        """Bare content block without role wrapped in user-role envelope."""
+        block = {"type": "image", "data": "Zg==", "mimeType": "image/png"}
+        result = _normalize_prompt_result(block)
+        assert result == [{"role": "user", "content": block}]
+
+    def test_image_missing_required_key_falls_back_to_string(self) -> None:
+        """Image block missing 'data' is malformed → stringified fallback."""
+        block = {"type": "image", "mimeType": "image/png"}
+        result = _normalize_prompt_result(block)
+        assert result[0]["content"]["type"] == "text"
+        assert "image" in result[0]["content"]["text"]
+
+    def test_content_list_inside_message_preserved(self) -> None:
+        """A list of content blocks under message.content is not flattened."""
+        blocks = [
+            {"type": "text", "text": "hi"},
+            {"type": "image", "data": "Zg==", "mimeType": "image/png"},
+        ]
+        msg = {"role": "user", "content": blocks}
+        assert _normalize_prompt_result(msg) == [msg]
 
 
 # ---------------------------------------------------------------------------
@@ -868,7 +1025,11 @@ class TestPromptErrorMapping:
             data = _rpc(client, "prompts/get", params={"name": "boom"})
             assert "error" in data
             assert data["error"]["code"] == -32603  # INTERNAL_ERROR
-            assert "kaboom" in data["error"]["message"]
+            # Per JSON-RPC 2.0 §5.1, structured exception context lives in
+            # the ``data`` member; the ``message`` is a stable label.
+            assert data["error"]["message"] == "Prompt execution failed"
+            assert "kaboom" in data["error"]["data"]["detail"]
+            assert data["error"]["data"]["error"] == "RuntimeError"
 
     def test_handler_4xx_maps_to_invalid_params(self) -> None:
         """Handler returning a 4xx Response surfaces as -32602 (INVALID_PARAMS).
@@ -964,3 +1125,131 @@ class TestPromptFiltering:
             data = _rpc(client, "prompts/get", params={"name": "hidden_fn"})
             assert "error" in data
             assert data["error"]["code"] == -32602
+
+
+# ---------------------------------------------------------------------------
+# Manifest (.well-known/mcp-server.json) capability + filter parity with
+# the JSON-RPC initialize/prompts/list responses.
+# ---------------------------------------------------------------------------
+
+
+class TestPromptsManifest:
+    def test_manifest_omits_prompts_capability_when_none_registered(self) -> None:
+        """Per MCP spec, advertise prompts capability only when prompts exist."""
+        app = _make_app_with_prompts()
+        with TestClient(app) as client:
+            payload = client.get("/.well-known/mcp-server.json").json()
+            assert "prompts" not in payload["capabilities"]
+            assert payload["prompts"] == []
+
+    def test_manifest_advertises_prompts_capability_when_registered(self) -> None:
+        @mcp_prompt(name="hello")
+        def hello() -> str:
+            return ""
+
+        app = _make_app_with_prompts(hello)
+        with TestClient(app) as client:
+            payload = client.get("/.well-known/mcp-server.json").json()
+            assert payload["capabilities"]["prompts"] == {"listChanged": True}
+            assert any(p["name"] == "hello" for p in payload["prompts"])
+
+    def test_manifest_filters_excluded_prompts(self) -> None:
+        """Manifest must apply should_include_prompt — must not leak hidden prompts."""
+
+        @mcp_prompt(name="hidden")
+        def hidden() -> str:
+            return ""
+
+        plugin = LitestarMCP(
+            config=MCPConfig(exclude_operations=["hidden"]),
+            prompts=[hidden],
+        )
+        app = Litestar(route_handlers=[], plugins=[plugin])
+        with TestClient(app) as client:
+            payload = client.get("/.well-known/mcp-server.json").json()
+            assert payload["prompts"] == []
+            assert "prompts" not in payload["capabilities"]
+
+
+# ---------------------------------------------------------------------------
+# C1 regression: ASGI handler exits without http.response.start
+# ---------------------------------------------------------------------------
+
+
+class TestCaptureAsgiResponseStatusZero:
+    """Cover the path where _capture_asgi_response observes no response start.
+
+    Without the C1 fix the function returned (None, 0), which slipped past
+    the >= 400 error gate in execute_handler, leaving callers to surface the
+    literal string "None" as a successful prompt body.
+    """
+
+    @pytest.mark.asyncio
+    async def test_asgi_app_without_response_start_classified_as_500(self) -> None:
+        from types import SimpleNamespace
+
+        from litestar_mcp.executor import _NON_JSON_STATUS, _capture_asgi_response
+
+        async def silent_asgi_app(scope: Any, receive: Any, send: Any) -> None:
+            return  # never calls send → no http.response.start
+
+        request_stub = SimpleNamespace(scope={"type": "http"}, receive=lambda: None)
+
+        content, status = await _capture_asgi_response(silent_asgi_app, request_stub)  # type: ignore[arg-type]
+        assert status == _NON_JSON_STATUS
+        assert isinstance(content, dict)
+        assert "error" in content
+        assert "without sending" in content["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# I4 regression: 4xx → JSON-RPC code mapping is narrow (400/422 only)
+# ---------------------------------------------------------------------------
+
+
+class TestPromptHandlerErrorCodeMapping:
+    """4xx classes other than 400/422 must NOT be reported as INVALID_PARAMS.
+
+    JSON-RPC INVALID_PARAMS (-32602) is reserved for invalid method
+    parameters. 401/403/404/409 are not parameter-validation failures and
+    should fall through to INTERNAL_ERROR until the dedicated error
+    taxonomy lands (issue #48).
+    """
+
+    @pytest.mark.parametrize("status_code", [401, 403, 404, 409])
+    def test_non_validation_4xx_maps_to_internal_error(self, status_code: int) -> None:
+        @get(
+            f"/handler-{status_code}",
+            mcp_prompt=f"prompt_{status_code}",
+            mcp_prompt_description="Handler that returns a non-validation 4xx",
+        )
+        async def handler() -> Response[dict]:
+            return Response({"error": "no"}, status_code=status_code)
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[handler], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/get", params={"name": f"prompt_{status_code}"})
+            assert "error" in data
+            assert data["error"]["code"] == -32603, (
+                f"{status_code} must map to INTERNAL_ERROR, not INVALID_PARAMS"
+            )
+
+    @pytest.mark.parametrize("status_code", [400, 422])
+    def test_validation_4xx_maps_to_invalid_params(self, status_code: int) -> None:
+        @get(
+            f"/validation-{status_code}",
+            mcp_prompt=f"prompt_v{status_code}",
+            mcp_prompt_description="Handler that returns a validation 4xx",
+        )
+        async def handler() -> Response[dict]:
+            return Response({"error": "bad input"}, status_code=status_code)
+
+        plugin = LitestarMCP(config=MCPConfig())
+        app = Litestar(route_handlers=[handler], plugins=[plugin])
+        with TestClient(app) as client:
+            data = _rpc(client, "prompts/get", params={"name": f"prompt_v{status_code}"})
+            assert "error" in data
+            assert data["error"]["code"] == -32602, (
+                f"{status_code} must map to INVALID_PARAMS (validation error)"
+            )


### PR DESCRIPTION
## Summary

Implements the MCP Prompts specification — the third primitive alongside tools and resources.

- **Standalone registration**: `@mcp_prompt` decorator + `LitestarMCP(prompts=[...])`
- **Handler-based registration**: opt-key discovery via `mcp_prompt` / `mcp_prompt_*`
- Full JSON-RPC support: `prompts/list`, `prompts/get`, capability advertisement, SSE notifications

Closes #45

## What's included

- `@mcp_prompt` decorator with metadata storage
- `PromptRegistration` frozen dataclass with `__post_init__` XOR guard (fn/handler)
- Google-style docstring argument enrichment (`_parse_docstring_args`) with indent-anchored continuation parsing
- `_normalize_prompt_result` with spec-compliant content variant recognition (text / image / audio / resource_link / resource)
- `MCPOptKeys.prompt`, `prompt_description`, `prompt_title`, `prompt_arguments`, `prompt_icons` config fields
- Manifest integration in `/.well-known/mcp-server.json` with capability gating + filter parity
- Handler-based prompts introspect arguments via `signature_model` (parity with tool validation)
- Conditional `prompts` capability advertisement (only when registered, both in `initialize` and the well-known manifest)

## Reviewer-flagged out-of-scope changes (executor.py)

This PR bundles a small but cross-cutting change to `litestar_mcp/executor.py`:

- `MCPToolErrorResult` gained `status_code: int` constructor param + `is_client_error` property
- `_dispatch_via_exception_handlers` return type changed from `tuple[Any, bool]` to `tuple[Any, int]`
- `is_error: bool` replaced with `status: int` throughout `execute_tool`
- Bare exception handler path now returns `(raw, 500)` instead of `(raw, True)`
- `_capture_asgi_response` now classifies a missing `http.response.start` as 500 (was previously slipping past the error gate as `(None, 0)`)

These changes were necessary to map handler-prompt errors to JSON-RPC error codes per the spec, but they affect **all tool-call dispatch**, not just prompts. Status was already captured internally and being discarded to a bool, so existing tool callers' behavior is preserved. External code catching `MCPToolErrorResult` sees a widened (not narrowed) interface. Reviewer suggested splitting into a separate commit/PR — noted for future scope discipline.

Also added: `execute_handler` alias for `execute_tool` so non-tool primitives (resources, prompts) dispatch through a name that does not lie about their purpose.

## Spec compliance

- MCP 2025-11-25 schema for `Prompt`, `PromptArgument`, `PromptMessage`
- Argument values enforced as `Record<string, string>`
- Content variants honored (text / image / audio / resource_link / resource)
- `_meta` echoed through to clients when handlers attach it
- `BaseMetadata.title` documented for `PromptArgument` (explicit pass-through)
- JSON-RPC `INVALID_PARAMS` (-32602) reserved for HTTP 400/422 (validation-shaped errors); other 4xx classes map to `INTERNAL_ERROR` per JSON-RPC §5.1 semantics
- JSON-RPC `data` member used for structured error context (handler-rendered payloads, exception name + detail) instead of stringifying dicts into `message`

**Known gaps (project-wide, separate issues):** pagination cursor on `*/list`, broader `_meta` plumbing, principled HTTP→JSON-RPC error taxonomy (#48), signature introspection convergence (#49).

## Review fixes (post-initial review)

- **C1** — `_capture_asgi_response` returns 500 with diagnostic content when ASGI app exits without `http.response.start`. Previously returned `(None, 0)` which slipped past the >= 400 error gate and surfaced as a JSON-RPC success envelope containing the literal string `"None"`.
- **C3** — Manifest gates `prompts` capability on registered+visible prompts; applies `should_include_prompt` filter to the manifest's `prompts` list so excluded prompts never leak via `.well-known/mcp-server.json`. Previously the manifest unconditionally advertised the capability and listed every registered prompt.
- **I1** — Docstring parser anchors continuation/parameter discrimination to indent depth. Continuation lines containing `:` (URLs, `Default: foo`) extend the current parameter's description instead of being misclassified as a new parameter.
- **I2** — `_introspect_handler_arguments` narrows `except Exception` to `(AttributeError, ImproperlyConfiguredException)`; logs unexpected errors so misconfigured handlers don't silently advertise zero arguments.
- **I3** — Comment at the prompt argument validation site now explains the spec-mandated divergence from tool-path validation (prompts: `Record<string, string>`; tools: structured msgspec.convert) and includes a hint that `data:` body parameters on the handler are intentionally ignored.
- **I4** — JSON-RPC error code mapping narrowed to spec-correct semantics (400/422 → INVALID_PARAMS, all other 4xx + 5xx → INTERNAL_ERROR). See #48 for the principled mapping module.
- **I5** — Structured error context lives in JSON-RPC `data` field; `message` is a stable label.
- **I6** — `jsonrpc.py` blanket catch logs via `_logger.exception` and surfaces structured `data`. Previously silent.
- **D1–D6** — Six docstring inaccuracies fixed: package summary mentions prompts, `register_prompt_handler` no longer claims `arguments=None` yields an empty list, runtime-layer drift removed from registry docstring, `get_arguments` correctly references `inspect.signature(fn)`, `_normalize_prompt_result` acknowledges role values are presence-checked only, `_parse_docstring_args` rewritten in valid Google-style.

## Test plan

- [x] Decorator metadata storage (name, title, description, arguments, icons)
- [x] PromptRegistration argument introspection
  - [x] fn-based: signature + docstring
  - [x] handler-based: `signature_model` with DI / context filter + docstring
  - [x] **NEW** DI/context filter coverage: `request`, `headers`, `Provide()` filtered
  - [x] **NEW** `resolve_dependencies()` failure does not propagate
- [x] Docstring parsing (Google-style, multi-line, type annotations, section boundaries)
  - [x] **NEW** continuation line w/ colon (URLs, `Default: foo`)
  - [x] **NEW** empty Args section, unindented terminator, line w/o colon
- [x] Result normalization (str, dict, list, content variants, other types)
  - [x] **NEW** image / audio / resource_link / resource passthrough
  - [x] **NEW** unwrapped image block wrapped in user envelope
  - [x] **NEW** malformed image (missing `data`) falls back to text
  - [x] **NEW** content list inside message preserved
- [x] Plugin registration (decorated prompts, rejection of undecorated functions)
- [x] JSON-RPC: `prompts/list` (empty, single, multiple, icons, docstring args)
- [x] JSON-RPC: `prompts/get` (sync, async, multi-message, errors)
- [x] Capability advertisement (advertised when prompts registered, omitted when none)
- [x] **NEW** Manifest (`/.well-known/mcp-server.json`)
  - [x] Omits `prompts` capability when none registered
  - [x] Advertises capability + lists prompts when registered
  - [x] Filters out prompts excluded via `should_include_prompt`
- [x] Handler-based prompt discovery via opt keys (title / arguments / icons end-to-end)
- [x] SSE notification broadcast (`notifications/prompts/list_changed`)
- [x] `_meta` echo on `prompts/get`
- [x] `PromptArgument.title` pass-through
- [x] Error mapping
  - [x] Standalone fn exception → `INTERNAL_ERROR`
  - [x] Handler 4xx Response → `INVALID_PARAMS` (status 400/422)
  - [x] Handler 5xx Response → `INTERNAL_ERROR`
  - [x] **NEW** Non-validation 4xx (401/403/404/409) → `INTERNAL_ERROR` (parametrized)
  - [x] **NEW** Validation 4xx (400/422) → `INVALID_PARAMS` (parametrized)
  - [x] Missing required handler arg → `INVALID_PARAMS`
  - [x] Unknown handler arg → `INVALID_PARAMS`
- [x] Filter coverage
  - [x] Handler prompt excluded by `exclude_operations` (hidden from list, 404 from get)
  - [x] Handler prompt excluded by `exclude_tags`
  - [x] Standalone prompt excluded by `exclude_operations` (name-based filter applies)
- [x] **NEW** Executor refactor regression sentinels
  - [x] `_capture_asgi_response` returns 500 + diagnostic on missing `http.response.start`
  - [x] Tool path captures real `MCPToolErrorResult.status_code` for 4xx and 5xx
- [x] Full test suite: **646 passed**, **86.26% coverage**, 21 deselected (pre-existing docs example failures unrelated to this PR)