### PR TITLE
fix: add cursor pagination to prompts/list, tools/list, and resources/list

### DIFF
--- a/litestar_mcp/_cursor.py
+++ b/litestar_mcp/_cursor.py
@@ -1,0 +1,25 @@
+"""Opaque cursor encoding shared by paginated list endpoints.
+
+The package-private leading underscore marks this module as internal: the
+encoding is an implementation detail and clients must treat cursors as opaque.
+"""
+
+import base64
+import binascii
+
+
+def encode_cursor(offset: int) -> str:
+    return base64.urlsafe_b64encode(str(offset).encode("utf-8")).decode("ascii")
+
+
+def decode_cursor(cursor: str) -> int:
+    try:
+        raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
+        offset = int(raw)
+    except (ValueError, binascii.Error) as exc:
+        msg = "Invalid cursor"
+        raise ValueError(msg) from exc
+    if offset < 0:
+        msg = "Invalid cursor"
+        raise ValueError(msg)
+    return offset

--- a/litestar_mcp/config.py
+++ b/litestar_mcp/config.py
@@ -111,6 +111,10 @@ class MCPConfig:
             is enforced on MCP endpoints.
         tasks: Optional task configuration or ``True`` to enable the default
             experimental in-memory task implementation.
+        list_page_size: Page size for ``tools/list``, ``resources/list``, and
+            ``prompts/list``. The MCP spec lets servers choose the page size;
+            clients page through results via the opaque ``cursor`` /
+            ``nextCursor`` round-trip. Must be a positive integer.
     """
 
     base_path: str = "/mcp"
@@ -129,6 +133,7 @@ class MCPConfig:
     session_max_idle_seconds: float = 3600.0
     sse_max_streams: int = 10_000
     sse_max_idle_seconds: float = 3600.0
+    list_page_size: int = 100
     _session_manager: Any = field(default=None, repr=False, compare=False)
 
     @property

--- a/litestar_mcp/config.py
+++ b/litestar_mcp/config.py
@@ -136,6 +136,11 @@ class MCPConfig:
     list_page_size: int = 100
     _session_manager: Any = field(default=None, repr=False, compare=False)
 
+    def __post_init__(self) -> None:
+        if self.list_page_size <= 0:
+            msg = f"list_page_size must be a positive integer, got {self.list_page_size}"
+            raise ValueError(msg)
+
     @property
     def task_config(self) -> "MCPTaskConfig | None":
         """Return the normalized task configuration, if task support is enabled."""

--- a/litestar_mcp/config.py
+++ b/litestar_mcp/config.py
@@ -113,8 +113,9 @@ class MCPConfig:
             experimental in-memory task implementation.
         list_page_size: Page size for ``tools/list``, ``resources/list``, and
             ``prompts/list``. The MCP spec lets servers choose the page size;
-            clients page through results via the opaque ``cursor`` /
-            ``nextCursor`` round-trip. Must be a positive integer.
+            clients cannot override it per request — they page through results
+            via the opaque ``cursor`` / ``nextCursor`` round-trip. Must be a
+            positive integer.
     """
 
     base_path: str = "/mcp"

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -7,7 +7,7 @@ import inspect
 import logging
 from collections.abc import AsyncGenerator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeVar
 
 from litestar import Controller, Litestar, MediaType, Request, Response, delete, get, post
 from litestar.di import NamedDependency
@@ -25,6 +25,7 @@ from litestar.status_codes import (
     HTTP_503_SERVICE_UNAVAILABLE,
 )
 
+from litestar_mcp._cursor import decode_cursor, encode_cursor
 from litestar_mcp.config import MCPConfig
 from litestar_mcp.executor import MCPToolErrorResult, execute_handler, execute_tool
 from litestar_mcp.jsonrpc import (
@@ -51,7 +52,6 @@ from litestar_mcp.registry import (
 from litestar_mcp.schema_builder import generate_schema_for_handler, parameter_aliases
 from litestar_mcp.sessions import MCPSessionManager, SessionTerminated
 from litestar_mcp.sse import StreamLimitExceeded
-from litestar_mcp._cursor import decode_cursor, encode_cursor
 from litestar_mcp.tasks import InMemoryTaskStore, TaskLookupError, TaskRecord, TaskStateError
 from litestar_mcp.utils import (
     get_handler_function,
@@ -149,13 +149,21 @@ def _build_request_context(request: Request[Any, Any, Any]) -> RequestContext:
     return RequestContext(client_id=client_id, owner_id=owner_id, request=request)
 
 
-def _paginate_list(items: list[Any], params: dict[str, Any], page_size: int) -> tuple[list[Any], str | None]:
+_T = TypeVar("_T")
+
+
+def _paginate_list(items: list[_T], params: dict[str, Any], page_size: int) -> tuple[list[_T], str | None]:
     """Slice ``items`` by the opaque cursor in ``params`` and return ``(page, next_cursor)``.
 
     Cursors are base64-encoded offsets — the same scheme used by ``tasks/list``.
     A missing cursor starts at offset 0; an out-of-range cursor returns an empty
     page with no ``nextCursor`` (treating "past the end" as "end of pagination"
     rather than an error, matching the spec's permissive client model).
+
+    Assumes ``items`` is stable for the lifetime of a pagination round-trip — the
+    list/prompt/resource registries are built at startup and not mutated, so
+    offset cursors remain valid. ``page_size`` is server-controlled (see
+    ``MCPConfig.list_page_size``); clients cannot override it per request.
     """
     cursor = params.get("cursor")
     if cursor is not None and not isinstance(cursor, str):

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -51,7 +51,7 @@ from litestar_mcp.registry import (
 from litestar_mcp.schema_builder import generate_schema_for_handler, parameter_aliases
 from litestar_mcp.sessions import MCPSessionManager, SessionTerminated
 from litestar_mcp.sse import StreamLimitExceeded
-from litestar_mcp.tasks import InMemoryTaskStore, TaskLookupError, TaskRecord, TaskStateError
+from litestar_mcp.tasks import InMemoryTaskStore, TaskLookupError, TaskRecord, TaskStateError, _decode_cursor, _encode_cursor
 from litestar_mcp.utils import (
     get_handler_function,
     get_mcp_metadata,
@@ -146,6 +146,26 @@ def _build_request_context(request: Request[Any, Any, Any]) -> RequestContext:
     sub = _request_subject(request)
     owner_id = f"user:{sub}" if sub is not None else f"client:{client_id}"
     return RequestContext(client_id=client_id, owner_id=owner_id, request=request)
+
+
+def _paginate_list(items: list[Any], params: dict[str, Any], page_size: int) -> tuple[list[Any], str | None]:
+    """Slice ``items`` by the opaque cursor in ``params`` and return ``(page, next_cursor)``.
+
+    Cursors are base64-encoded offsets — the same scheme used by ``tasks/list``.
+    A missing cursor starts at offset 0; an out-of-range cursor returns an empty
+    page with no ``nextCursor`` (treating "past the end" as "end of pagination"
+    rather than an error, matching the spec's permissive client model).
+    """
+    cursor = params.get("cursor")
+    if cursor is not None and not isinstance(cursor, str):
+        raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message="The 'cursor' parameter must be a string"))
+    try:
+        offset = _decode_cursor(cursor) if cursor else 0
+    except ValueError as exc:
+        raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message=str(exc))) from exc
+    page = items[offset : offset + page_size]
+    next_cursor = _encode_cursor(offset + page_size) if offset + page_size < len(items) else None
+    return page, next_cursor
 
 
 def _serialize_tool_content(value: Any) -> str:
@@ -416,7 +436,7 @@ def build_jsonrpc_router(
 
     router.register("ping", handle_ping)
 
-    async def handle_tools_list(params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
+    async def handle_tools_list(params: dict[str, Any]) -> dict[str, Any]:
         tools = []
         for name, handler in discovered_tools.items():
             handler_tags = set(getattr(handler, "tags", None) or [])
@@ -444,7 +464,11 @@ def build_jsonrpc_router(
             if task_config is not None and metadata.get("task_support") is not None:
                 tool_entry["execution"] = {"taskSupport": metadata["task_support"]}
             tools.append(tool_entry)
-        return {"tools": tools}
+        page, next_cursor = _paginate_list(tools, params, config.list_page_size)
+        result: dict[str, Any] = {"tools": page}
+        if next_cursor is not None:
+            result["nextCursor"] = next_cursor
+        return result
 
     router.register("tools/list", handle_tools_list)
 
@@ -493,7 +517,7 @@ def build_jsonrpc_router(
 
     router.register("tools/call", handle_tools_call)
 
-    async def handle_resources_list(params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
+    async def handle_resources_list(params: dict[str, Any]) -> dict[str, Any]:
         resources = [
             {
                 "uri": "litestar://openapi",
@@ -518,7 +542,11 @@ def build_jsonrpc_router(
                     "mimeType": "application/json",
                 }
             )
-        return {"resources": resources}
+        page, next_cursor = _paginate_list(resources, params, config.list_page_size)
+        result: dict[str, Any] = {"resources": page}
+        if next_cursor is not None:
+            result["nextCursor"] = next_cursor
+        return result
 
     router.register("resources/list", handle_resources_list)
 
@@ -640,13 +668,17 @@ def build_jsonrpc_router(
 
     router.register("completion/complete", handle_completion_complete)
 
-    async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:  # noqa: ARG001
+    async def handle_prompts_list(params: dict[str, Any]) -> dict[str, Any]:
         prompts = [
             render_prompt_entry(registration, config)
             for registration in discovered_prompts.values()
             if should_include_prompt(registration, config)
         ]
-        return {"prompts": prompts}
+        page, next_cursor = _paginate_list(prompts, params, config.list_page_size)
+        result: dict[str, Any] = {"prompts": page}
+        if next_cursor is not None:
+            result["nextCursor"] = next_cursor
+        return result
 
     router.register("prompts/list", handle_prompts_list)
 

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -167,7 +167,9 @@ def _paginate_list(items: list[_T], params: dict[str, Any], page_size: int) -> t
     """
     cursor = params.get("cursor")
     if cursor is not None and not isinstance(cursor, str):
-        raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message="The 'cursor' parameter must be a string"))
+        raise JSONRPCErrorException(
+            JSONRPCError(code=INVALID_PARAMS, message="The 'cursor' parameter must be a string")
+        )
     try:
         offset = decode_cursor(cursor) if cursor else 0
     except ValueError as exc:

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -51,7 +51,8 @@ from litestar_mcp.registry import (
 from litestar_mcp.schema_builder import generate_schema_for_handler, parameter_aliases
 from litestar_mcp.sessions import MCPSessionManager, SessionTerminated
 from litestar_mcp.sse import StreamLimitExceeded
-from litestar_mcp.tasks import InMemoryTaskStore, TaskLookupError, TaskRecord, TaskStateError, _decode_cursor, _encode_cursor
+from litestar_mcp._cursor import decode_cursor, encode_cursor
+from litestar_mcp.tasks import InMemoryTaskStore, TaskLookupError, TaskRecord, TaskStateError
 from litestar_mcp.utils import (
     get_handler_function,
     get_mcp_metadata,
@@ -160,11 +161,11 @@ def _paginate_list(items: list[Any], params: dict[str, Any], page_size: int) -> 
     if cursor is not None and not isinstance(cursor, str):
         raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message="The 'cursor' parameter must be a string"))
     try:
-        offset = _decode_cursor(cursor) if cursor else 0
+        offset = decode_cursor(cursor) if cursor else 0
     except ValueError as exc:
         raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message=str(exc))) from exc
     page = items[offset : offset + page_size]
-    next_cursor = _encode_cursor(offset + page_size) if offset + page_size < len(items) else None
+    next_cursor = encode_cursor(offset + page_size) if offset + page_size < len(items) else None
     return page, next_cursor
 
 

--- a/litestar_mcp/tasks.py
+++ b/litestar_mcp/tasks.py
@@ -267,5 +267,3 @@ def _utc_now() -> datetime:
 
 def _format_datetime(value: datetime) -> str:
     return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-

--- a/litestar_mcp/tasks.py
+++ b/litestar_mcp/tasks.py
@@ -1,13 +1,12 @@
 """Experimental MCP task support."""
 
 import asyncio
-import base64
-import binascii
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
+from litestar_mcp._cursor import decode_cursor, encode_cursor
 from litestar_mcp.jsonrpc import INTERNAL_ERROR, JSONRPCError
 
 if TYPE_CHECKING:
@@ -127,13 +126,13 @@ class InMemoryTaskStore:
     ) -> tuple[list[TaskRecord], str | None]:
         async with self._lock:
             self._purge_expired_locked()
-            offset = _decode_cursor(cursor) if cursor is not None else 0
+            offset = decode_cursor(cursor) if cursor is not None else 0
             owned_tasks = [self._clone_record(task) for task in self._tasks.values() if task.owner_id == owner_id]
             owned_tasks.sort(key=lambda item: item.created_at)
             page = owned_tasks[offset : offset + limit]
             next_cursor = None
             if offset + limit < len(owned_tasks):
-                next_cursor = _encode_cursor(offset + limit)
+                next_cursor = encode_cursor(offset + limit)
             return page, next_cursor
 
     async def wait_for_terminal(self, task_id: str, owner_id: str) -> TaskRecord:
@@ -270,14 +269,3 @@ def _format_datetime(value: datetime) -> str:
     return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def _encode_cursor(offset: int) -> str:
-    return base64.urlsafe_b64encode(str(offset).encode("utf-8")).decode("ascii")
-
-
-def _decode_cursor(cursor: str) -> int:
-    try:
-        raw = base64.urlsafe_b64decode(cursor.encode("ascii")).decode("utf-8")
-        return int(raw)
-    except (ValueError, binascii.Error) as exc:
-        msg = "Invalid cursor"
-        raise ValueError(msg) from exc

--- a/tests/unit/test_list_pagination.py
+++ b/tests/unit/test_list_pagination.py
@@ -1,0 +1,160 @@
+"""Cursor pagination for ``tools/list``, ``resources/list``, ``prompts/list``."""
+
+from typing import Any
+
+from litestar import Litestar, get
+from litestar.testing import TestClient
+
+from litestar_mcp import LitestarMCP, mcp_prompt
+from litestar_mcp.config import MCPConfig
+
+
+def _rpc(
+    client: TestClient[Any],
+    method: str,
+    params: "dict[str, Any] | None" = None,
+    headers: "dict[str, str] | None" = None,
+) -> Any:
+    body: dict[str, Any] = {"jsonrpc": "2.0", "id": 1, "method": method}
+    if params is not None:
+        body["params"] = params
+    return client.post("/mcp", json=body, headers=headers or {})
+
+
+def _init_session(client: TestClient[Any]) -> str:
+    init = _rpc(
+        client,
+        "initialize",
+        {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "x"}},
+    )
+    sid = init.headers["mcp-session-id"]
+    client.post(
+        "/mcp",
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers={"Mcp-Session-Id": sid},
+    )
+    return sid
+
+
+def _make_tools_app(count: int, page_size: int) -> Litestar:
+    handlers = []
+    for i in range(count):
+
+        @get(f"/t{i}", name=f"t{i}", opt={"mcp_tool": f"tool_{i:03d}"}, sync_to_thread=False)
+        def _h() -> dict[str, int]:
+            return {"i": 0}
+
+        handlers.append(_h)
+    return Litestar(route_handlers=handlers, plugins=[LitestarMCP(config=MCPConfig(list_page_size=page_size))])
+
+
+def test_tools_list_paginates_with_next_cursor() -> None:
+    app = _make_tools_app(count=5, page_size=2)
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        headers = {"Mcp-Session-Id": sid}
+
+        # Page 1
+        r1 = _rpc(client, "tools/list", {}, headers=headers).json()["result"]
+        assert len(r1["tools"]) == 2
+        assert "nextCursor" in r1
+
+        # Page 2
+        r2 = _rpc(client, "tools/list", {"cursor": r1["nextCursor"]}, headers=headers).json()["result"]
+        assert len(r2["tools"]) == 2
+        assert "nextCursor" in r2
+
+        # Page 3 — final page, no nextCursor
+        r3 = _rpc(client, "tools/list", {"cursor": r2["nextCursor"]}, headers=headers).json()["result"]
+        assert len(r3["tools"]) == 1
+        assert "nextCursor" not in r3
+
+        all_names = [t["name"] for t in r1["tools"] + r2["tools"] + r3["tools"]]
+        assert all_names == [f"tool_{i:03d}" for i in range(5)]
+
+
+def test_tools_list_single_page_omits_next_cursor() -> None:
+    app = _make_tools_app(count=2, page_size=100)
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        result = _rpc(client, "tools/list", {}, headers={"Mcp-Session-Id": sid}).json()["result"]
+        assert len(result["tools"]) == 2
+        assert "nextCursor" not in result
+
+
+def test_tools_list_rejects_invalid_cursor() -> None:
+    app = _make_tools_app(count=3, page_size=2)
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        resp = _rpc(client, "tools/list", {"cursor": "!!!not-base64!!!"}, headers={"Mcp-Session-Id": sid}).json()
+        assert resp["error"]["code"] == -32602
+
+
+def test_tools_list_rejects_non_string_cursor() -> None:
+    app = _make_tools_app(count=3, page_size=2)
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        resp = _rpc(client, "tools/list", {"cursor": 42}, headers={"Mcp-Session-Id": sid}).json()
+        assert resp["error"]["code"] == -32602
+
+
+def test_tools_list_cursor_past_end_returns_empty_page() -> None:
+    import base64
+
+    app = _make_tools_app(count=3, page_size=2)
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        far = base64.urlsafe_b64encode(b"99").decode("ascii")
+        result = _rpc(client, "tools/list", {"cursor": far}, headers={"Mcp-Session-Id": sid}).json()["result"]
+        assert result["tools"] == []
+        assert "nextCursor" not in result
+
+
+def test_resources_list_paginates() -> None:
+    handlers = []
+    # The built-in litestar://openapi resource counts as one entry.
+    for i in range(4):
+
+        @get(f"/r{i}", name=f"r{i}", opt={"mcp_resource": f"res_{i:03d}"}, sync_to_thread=False)
+        def _h() -> dict[str, int]:
+            return {"i": 0}
+
+        handlers.append(_h)
+    app = Litestar(route_handlers=handlers, plugins=[LitestarMCP(config=MCPConfig(list_page_size=2))])
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        headers = {"Mcp-Session-Id": sid}
+        r1 = _rpc(client, "resources/list", {}, headers=headers).json()["result"]
+        assert len(r1["resources"]) == 2
+        assert "nextCursor" in r1
+        r2 = _rpc(client, "resources/list", {"cursor": r1["nextCursor"]}, headers=headers).json()["result"]
+        assert len(r2["resources"]) == 2
+        assert "nextCursor" in r2
+        r3 = _rpc(client, "resources/list", {"cursor": r2["nextCursor"]}, headers=headers).json()["result"]
+        assert len(r3["resources"]) == 1
+        assert "nextCursor" not in r3
+
+
+def test_prompts_list_paginates() -> None:
+    @mcp_prompt(name="p_a")
+    def p_a() -> str:
+        return "a"
+
+    @mcp_prompt(name="p_b")
+    def p_b() -> str:
+        return "b"
+
+    @mcp_prompt(name="p_c")
+    def p_c() -> str:
+        return "c"
+
+    app = Litestar(plugins=[LitestarMCP(prompts=[p_a, p_b, p_c], config=MCPConfig(list_page_size=2))])
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        headers = {"Mcp-Session-Id": sid}
+        r1 = _rpc(client, "prompts/list", {}, headers=headers).json()["result"]
+        assert len(r1["prompts"]) == 2
+        assert "nextCursor" in r1
+        r2 = _rpc(client, "prompts/list", {"cursor": r1["nextCursor"]}, headers=headers).json()["result"]
+        assert len(r2["prompts"]) == 1
+        assert "nextCursor" not in r2

--- a/tests/unit/test_list_pagination.py
+++ b/tests/unit/test_list_pagination.py
@@ -28,7 +28,7 @@ def _init_session(client: TestClient[Any]) -> str:
         "initialize",
         {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "x"}},
     )
-    sid = init.headers["mcp-session-id"]
+    sid: str = init.headers["mcp-session-id"]
     client.post(
         "/mcp",
         json={"jsonrpc": "2.0", "method": "notifications/initialized"},

--- a/tests/unit/test_list_pagination.py
+++ b/tests/unit/test_list_pagination.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 
+import pytest
 from litestar import Litestar, get
 from litestar.testing import TestClient
 
@@ -158,3 +159,27 @@ def test_prompts_list_paginates() -> None:
         r2 = _rpc(client, "prompts/list", {"cursor": r1["nextCursor"]}, headers=headers).json()["result"]
         assert len(r2["prompts"]) == 1
         assert "nextCursor" not in r2
+
+
+def test_tools_list_empty_registry_returns_empty_page() -> None:
+    app = Litestar(plugins=[LitestarMCP(config=MCPConfig(list_page_size=10))])
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        result = _rpc(client, "tools/list", {}, headers={"Mcp-Session-Id": sid}).json()["result"]
+        assert result["tools"] == []
+        assert "nextCursor" not in result
+
+
+def test_prompts_list_empty_registry_returns_empty_page() -> None:
+    app = Litestar(plugins=[LitestarMCP(config=MCPConfig(list_page_size=10))])
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        result = _rpc(client, "prompts/list", {}, headers={"Mcp-Session-Id": sid}).json()["result"]
+        assert result["prompts"] == []
+        assert "nextCursor" not in result
+
+
+@pytest.mark.parametrize("bad_size", [0, -1, -100])
+def test_mcp_config_rejects_non_positive_list_page_size(bad_size: int) -> None:
+    with pytest.raises(ValueError, match="list_page_size must be a positive integer"):
+        MCPConfig(list_page_size=bad_size)

--- a/tests/unit/test_list_pagination.py
+++ b/tests/unit/test_list_pagination.py
@@ -99,6 +99,17 @@ def test_tools_list_rejects_non_string_cursor() -> None:
         assert resp["error"]["code"] == -32602
 
 
+def test_tools_list_rejects_negative_offset_cursor() -> None:
+    import base64
+
+    app = _make_tools_app(count=3, page_size=2)
+    with TestClient(app=app) as client:
+        sid = _init_session(client)
+        negative = base64.urlsafe_b64encode(b"-1").decode("ascii")
+        resp = _rpc(client, "tools/list", {"cursor": negative}, headers={"Mcp-Session-Id": sid}).json()
+        assert resp["error"]["code"] == -32602
+
+
 def test_tools_list_cursor_past_end_returns_empty_page() -> None:
     import base64
 


### PR DESCRIPTION
## Summary

- Closes #47.
- Adds opaque `cursor` / `nextCursor` pagination to `tools/list`, `resources/list`, and `prompts/list`, reusing the base64-offset cursor scheme already used by `tasks/list`.
- New `MCPConfig.list_page_size` field (default `100`) controls page size for all three endpoints.
- Invalid or non-string cursors return `INVALID_PARAMS` (-32602); cursors past the end return an empty page with no `nextCursor` (spec-permissive client model).

## Test plan

- [x] Unit tests for happy-path multi-page traversal across all three endpoints
- [x] Single-page case omits `nextCursor`
- [x] Invalid base64 cursor → `INVALID_PARAMS`
- [x] Non-string cursor → `INVALID_PARAMS`
- [x] Cursor past end → empty page, no error
- [x] Full unit suite: 582 passed, 1 skipped, no regressions