### PR TITLE
docs: document MCP Prompts and split usage primitives per spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Litestar MCP Plugin
 
-A lightweight plugin that integrates Litestar web applications with the Model Context Protocol (MCP) by exposing marked routes as MCP tools and resources over MCP Streamable HTTP and JSON-RPC.
+A lightweight plugin that integrates Litestar web applications with the Model Context Protocol (MCP) by exposing marked routes as MCP tools, resources, and prompts over MCP Streamable HTTP and JSON-RPC.
 
 [![PyPI - Version](https://img.shields.io/pypi/v/litestar-mcp)](https://pypi.org/project/litestar-mcp/)
 [![Python Version](https://img.shields.io/pypi/pyversions/litestar-mcp)](https://pypi.org/project/litestar-mcp/)
@@ -8,12 +8,13 @@ A lightweight plugin that integrates Litestar web applications with the Model Co
 
 ## Overview
 
-This plugin automatically discovers Litestar routes marked for MCP and exposes them through an MCP-native transport surface. Pass `mcp_tool="name"` or `mcp_resource="name"` straight through to `@get` / `@post` / etc. — Litestar funnels unknown kwargs into `handler.opt`, so no second decorator or `opt={...}` wrapper is needed.
+This plugin automatically discovers Litestar routes marked for MCP and exposes them through an MCP-native transport surface. Pass `mcp_tool="name"`, `mcp_resource="name"`, or `mcp_prompt="name"` straight through to `@get` / `@post` / etc. — Litestar funnels unknown kwargs into `handler.opt`, so no second decorator or `opt={...}` wrapper is needed. Standalone prompt callables that are not bound to an HTTP route can be registered through `LitestarMCP(prompts=[...])`.
 
 ## Features
 
 - **Protocol-Native Transport** — MCP Streamable HTTP with JSON-RPC requests and SSE streams.
-- **Simple Route Marking** — pass `mcp_tool` / `mcp_resource` kwargs straight through to Litestar's route decorators.
+- **Three MCP Primitives** — tools, resources, *and* prompts, with `prompts/list` and `prompts/get` driven by the same handler discovery as the rest of the surface.
+- **Simple Route Marking** — pass `mcp_tool` / `mcp_resource` / `mcp_prompt` kwargs straight through to Litestar's route decorators, or register standalone prompts via `LitestarMCP(prompts=[...])`.
 - **RFC 6570 URI Templates** — `mcp_resource_template="app://…/{var}"` dispatches concrete URIs to handlers with extracted vars.
 - **First-Class Descriptions** — structured `mcp_description`, `mcp_agent_instructions`, `mcp_when_to_use`, `mcp_returns` kwargs.
 - **Type Safe** — full type hints with dataclasses; `msgspec`-powered tool-argument validation.

--- a/docs/examples/snippets/configuration_prompts.py
+++ b/docs/examples/snippets/configuration_prompts.py
@@ -1,0 +1,29 @@
+"""Snippet: register standalone prompts. Referenced from docs/usage/configuration.rst."""
+
+from litestar import Litestar
+
+from litestar_mcp import LitestarMCP, MCPConfig, mcp_prompt
+
+
+@mcp_prompt(name="greet", description="Greet a user by name.")
+async def greet(name: str) -> str:
+    """Build a greeting prompt.
+
+    Args:
+        name: The user's name to greet.
+    """
+    return f"Please greet {name} warmly."
+
+
+def build() -> Litestar:
+    # start-example
+    app = Litestar(
+        plugins=[
+            LitestarMCP(
+                MCPConfig(name="prompt-demo"),
+                prompts=[greet],
+            ),
+        ],
+    )
+    # end-example
+    return app

--- a/docs/examples/snippets/configuration_prompts.py
+++ b/docs/examples/snippets/configuration_prompts.py
@@ -18,6 +18,7 @@ async def greet(name: str) -> str:
 def build() -> Litestar:
     # start-example
     app = Litestar(
+        route_handlers=[],
         plugins=[
             LitestarMCP(
                 MCPConfig(name="prompt-demo"),

--- a/docs/examples/snippets/marking_prompts.py
+++ b/docs/examples/snippets/marking_prompts.py
@@ -1,0 +1,34 @@
+"""Snippet: marking and registering MCP prompts. Referenced from docs/usage/marking_routes.rst."""
+
+from litestar import Litestar, get
+
+from litestar_mcp import LitestarMCP, mcp_prompt
+
+
+def build() -> Litestar:
+    # start-example
+    @mcp_prompt(name="summarize", description="Summarise a document in a chosen style.")
+    async def summarize(text: str, style: str = "concise") -> str:
+        """Build a summarisation prompt.
+
+        Args:
+            text: The document to summarise.
+            style: Summary style, e.g. ``concise`` or ``detailed``.
+        """
+        return f"Summarise the following in a {style} style:\n\n{text}"
+
+    @get(
+        "/prompts/code-review",
+        mcp_prompt="code_review",
+        mcp_prompt_description="Ask the model to review a code diff.",
+    )
+    async def code_review(code: str) -> dict[str, object]:
+        """Handler-based prompt: routed under HTTP *and* exposed via ``prompts/get``."""
+        return {"messages": [{"role": "user", "content": {"type": "text", "text": f"Review: {code}"}}]}
+
+    app = Litestar(
+        route_handlers=[code_review],
+        plugins=[LitestarMCP(prompts=[summarize])],
+    )
+    # end-example
+    return app

--- a/docs/examples/task_manager/main.py
+++ b/docs/examples/task_manager/main.py
@@ -30,7 +30,7 @@ from litestar.openapi.config import OpenAPIConfig
 from litestar.status_codes import HTTP_201_CREATED
 from pydantic import BaseModel
 
-from litestar_mcp import LitestarMCP, MCPConfig
+from litestar_mcp import LitestarMCP, MCPConfig, mcp_prompt
 
 
 class Task(BaseModel):
@@ -84,6 +84,39 @@ def register_resources(store: "dict[int, Task]") -> "list[Any]":
 
     # end-example
     return [get_task_schema, get_api_info]
+
+
+def register_prompts(store: "dict[int, Task]") -> "list[Any]":
+    """Return standalone MCP prompts bound to ``store``.
+
+    Prompts are templated instructions for an LLM. Unlike tools (which execute)
+    and resources (which return data), prompts return a list of messages the
+    client feeds back into the model. Returning a plain ``str`` is the
+    simplest form — the plugin wraps it as a single user-role text message.
+    """
+
+    # start-example
+    @mcp_prompt(
+        name="summarize_tasks",
+        title="Summarize tasks",
+        description="Ask the model to summarize the current task list in a chosen style.",
+    )
+    async def summarize_tasks(style: str = "concise") -> str:
+        """Build a prompt summarizing the task store.
+
+        Args:
+            style: Summary style hint, e.g. ``concise``, ``detailed``,
+                ``bullet-points``. Used verbatim in the prompt body.
+        """
+        lines = [
+            f"- [{'x' if task.completed else ' '}] {task.title}: {task.description}"
+            for task in store.values()
+        ]
+        body = "\n".join(lines) if lines else "(no tasks)"
+        return f"Summarise the following tasks in a {style} style:\n\n{body}"
+
+    # end-example
+    return [summarize_tasks]
 
 
 def register_tools(store: "dict[int, Task]") -> "list[Any]":
@@ -153,6 +186,7 @@ def build_app(tasks: "dict[int, Task] | None" = None) -> Litestar:
 
     resource_handlers = register_resources(store)
     tool_handlers = register_tools(store)
+    prompts = register_prompts(store)
 
     # start-example
     mcp_config = MCPConfig(
@@ -167,7 +201,7 @@ def build_app(tasks: "dict[int, Task] | None" = None) -> Litestar:
             root,
             health_check,
         ],
-        plugins=[LitestarMCP(mcp_config)],
+        plugins=[LitestarMCP(mcp_config, prompts=prompts)],
         openapi_config=OpenAPIConfig(
             title="Task Management API",
             version="1.0.0",

--- a/docs/examples/task_manager/main.py
+++ b/docs/examples/task_manager/main.py
@@ -108,10 +108,7 @@ def register_prompts(store: "dict[int, Task]") -> "list[Any]":
             style: Summary style hint, e.g. ``concise``, ``detailed``,
                 ``bullet-points``. Used verbatim in the prompt body.
         """
-        lines = [
-            f"- [{'x' if task.completed else ' '}] {task.title}: {task.description}"
-            for task in store.values()
-        ]
+        lines = [f"- [{'x' if task.completed else ' '}] {task.title}: {task.description}" for task in store.values()]
         body = "\n".join(lines) if lines else "(no tasks)"
         return f"Summarise the following tasks in a {style} style:\n\n{body}"
 

--- a/docs/examples/task_manager/test_task_manager.py
+++ b/docs/examples/task_manager/test_task_manager.py
@@ -78,6 +78,26 @@ def test_resources_list_exposes_expected_resources(fresh_client: TestClient[Any]
     assert any(uri.endswith("api_info") for uri in uris)
 
 
+def test_prompts_list_exposes_summarize_tasks(fresh_client: TestClient[Any]) -> None:
+    result = _rpc(fresh_client, "prompts/list", {})
+    names = {prompt["name"] for prompt in result["result"]["prompts"]}
+    assert "summarize_tasks" in names
+
+
+def test_prompts_get_summarize_tasks_includes_seed(fresh_client: TestClient[Any]) -> None:
+    result = _rpc(
+        fresh_client,
+        "prompts/get",
+        {"name": "summarize_tasks", "arguments": {"style": "detailed"}},
+    )
+    messages = result["result"]["messages"]
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    text = messages[0]["content"]["text"]
+    assert "detailed" in text
+    assert "seed-1" in text
+
+
 def test_create_task_via_rest_round_trips(fresh_client: TestClient[Any]) -> None:
     """Create a task through the HTTP surface and confirm it is listed back.
 

--- a/docs/examples/task_manager/test_task_manager.py
+++ b/docs/examples/task_manager/test_task_manager.py
@@ -93,9 +93,33 @@ def test_prompts_get_summarize_tasks_includes_seed(fresh_client: TestClient[Any]
     messages = result["result"]["messages"]
     assert len(messages) == 1
     assert messages[0]["role"] == "user"
-    text = messages[0]["content"]["text"]
+    content = messages[0]["content"]
+    assert content["type"] == "text"
+    text = content["text"]
     assert "detailed" in text
     assert "seed-1" in text
+
+
+def test_prompts_get_summarize_tasks_uses_default_style(fresh_client: TestClient[Any]) -> None:
+    """Omitting ``arguments`` must fall back to the handler's ``style="concise"`` default."""
+    result = _rpc(fresh_client, "prompts/get", {"name": "summarize_tasks"})
+    text = result["result"]["messages"][0]["content"]["text"]
+    assert "concise" in text
+
+
+def test_prompts_get_summarize_tasks_empty_store_renders_fallback() -> None:
+    """With no tasks the prompt body must use the ``(no tasks)`` literal, not crash."""
+    with TestClient(app=build_app(tasks={})) as client:
+        result = _rpc(client, "prompts/get", {"name": "summarize_tasks"})
+        text = result["result"]["messages"][0]["content"]["text"]
+        assert "(no tasks)" in text
+
+
+def test_prompts_get_unknown_name_returns_mcp_error(fresh_client: TestClient[Any]) -> None:
+    """Requesting an unregistered prompt must surface as an MCP error envelope."""
+    result = _rpc(fresh_client, "prompts/get", {"name": "does_not_exist"})
+    assert "jsonrpc" in result
+    assert ("error" in result) or result.get("result", {}).get("isError") is True
 
 
 def test_create_task_via_rest_round_trips(fresh_client: TestClient[Any]) -> None:

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -12,3 +12,16 @@ MCPConfig
 .. autoclass:: MCPConfig
    :members:
    :show-inheritance:
+
+MCPOptKeys
+----------
+
+The opt-key names used to mark Litestar route handlers as MCP tools,
+resources, or prompts. Field defaults match the documented kwargs
+(``mcp_tool``, ``mcp_resource``, ``mcp_prompt``, ``mcp_prompt_description``,
+``mcp_prompt_title``, ``mcp_prompt_arguments``, ``mcp_prompt_icons``, …);
+override the dataclass to remap a project to non-default opt keys.
+
+.. autoclass:: MCPOptKeys
+   :members:
+   :show-inheritance:

--- a/docs/reference/handlers.rst
+++ b/docs/reference/handlers.rst
@@ -1,8 +1,9 @@
-=======
-Routes
-=======
+=========================
+Handlers and Decorators
+=========================
 
-This module contains the MCP route handlers and controllers.
+This module contains the MCP route controller and the decorator markers
+used to attach MCP metadata to handlers and standalone callables.
 
 .. currentmodule:: litestar_mcp.routes
 
@@ -12,3 +13,14 @@ MCPController
 .. autoclass:: MCPController
    :members:
    :show-inheritance:
+
+.. currentmodule:: litestar_mcp
+
+Markers
+-------
+
+.. autofunction:: mcp_tool
+
+.. autofunction:: mcp_resource
+
+.. autofunction:: mcp_prompt

--- a/docs/reference/plugin.rst
+++ b/docs/reference/plugin.rst
@@ -14,8 +14,11 @@ LitestarMCP
    :show-inheritance:
 
    The main plugin class that implements :class:`litestar.plugins.InitPluginProtocol`.
-   It discovers routes marked with ``mcp_tool`` or ``mcp_resource`` in their ``opt``
-   dictionary and exposes them through the MCP Streamable HTTP transport surface.
+   It discovers routes marked with ``mcp_tool``, ``mcp_resource``, or
+   ``mcp_prompt`` in their ``opt`` dictionary and exposes them through the
+   MCP Streamable HTTP transport surface. Standalone prompt callables
+   decorated with :func:`~litestar_mcp.mcp_prompt` can be passed via the
+   ``prompts`` constructor argument.
 
 .. currentmodule:: litestar_mcp.registry
 

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -20,6 +20,19 @@ MCPTaskConfig
    :members:
    :show-inheritance:
 
+.. currentmodule:: litestar_mcp.registry
+
+PromptRegistration
+------------------
+
+See also :class:`~litestar_mcp.config.MCPOptKeys` (documented under
+:doc:`config`) for the opt-key field names that drive handler-based
+prompt discovery.
+
+.. autoclass:: PromptRegistration
+   :members:
+   :show-inheritance:
+
 .. currentmodule:: litestar_mcp.auth
 
 MCPAuthConfig

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -46,6 +46,25 @@ See :doc:`auth` for the full authentication story.
     :end-before: # end-example
     :dedent:
 
+Standalone Prompts
+==================
+
+Prompt callables that are not bound to an HTTP route are registered by
+passing them to ``LitestarMCP(prompts=[...])``. Each function must first
+be decorated with :func:`~litestar_mcp.mcp_prompt`; the plugin rejects
+plain callables to keep prompt metadata explicit.
+
+.. literalinclude:: /examples/snippets/configuration_prompts.py
+    :language: python
+    :caption: ``docs/examples/snippets/configuration_prompts.py``
+    :start-after: # start-example
+    :end-before: # end-example
+    :dedent:
+
+See :doc:`marking_routes` for the handler-based ``mcp_prompt`` opt-key
+form, which routes a prompt under HTTP *and* publishes it via
+``prompts/get``.
+
 Task Lifecycle
 ==============
 
@@ -97,6 +116,10 @@ Configuration Options
     * - ``tasks``
       - ``False``
       - Enable experimental in-memory MCP task support.
+
+The ``LitestarMCP`` constructor also accepts a top-level ``prompts``
+argument — a sequence of ``@mcp_prompt``-decorated callables — for
+standalone prompt registration (see above).
 
 Environment Overrides
 =====================

--- a/docs/usage/discovery.rst
+++ b/docs/usage/discovery.rst
@@ -52,11 +52,20 @@ and capabilities. A minimal response looks like:
       "capabilities": {
         "tools": {"listChanged": true},
         "resources": {"subscribe": true, "listChanged": true},
+        "prompts": {"listChanged": true},
         "tasks": false
       },
       "tools": [],
-      "resources": []
+      "resources": [],
+      "prompts": []
     }
+
+The ``prompts`` capability is **gated**: it is only advertised — both in
+this manifest and in ``initialize``'s capability response — when at least
+one visible prompt is registered. This matches the MCP spec's
+recommendation that servers only declare capabilities for primitives they
+actually expose. The same per-tag and per-operation include/exclude
+filters that apply to tools and resources also gate prompt visibility.
 
 Agent Metadata Card
 ===================

--- a/docs/usage/discovery.rst
+++ b/docs/usage/discovery.rst
@@ -52,7 +52,6 @@ and capabilities. A minimal response looks like:
       "capabilities": {
         "tools": {"listChanged": true},
         "resources": {"subscribe": true, "listChanged": true},
-        "prompts": {"listChanged": true},
         "tasks": false
       },
       "tools": [],
@@ -60,9 +59,15 @@ and capabilities. A minimal response looks like:
       "prompts": []
     }
 
+The ``protocolVersion`` value mirrors the
+:data:`litestar_mcp.manifests.MCP_PROTOCOL_VERSION` constant and will move
+in lock-step with the implementation; do not pin against the string above.
+
 The ``prompts`` capability is **gated**: it is only advertised — both in
 this manifest and in ``initialize``'s capability response — when at least
-one visible prompt is registered. This matches the MCP spec's
+one visible prompt is registered. That is why the minimal capabilities
+block above omits ``prompts`` entirely while the top-level ``prompts``
+array is still present (empty). This matches the MCP spec's
 recommendation that servers only declare capabilities for primitives they
 actually expose. The same per-tag and per-operation include/exclude
 filters that apply to tools and resources also gate prompt visibility.

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -22,15 +22,29 @@ examples drawn from :mod:`docs.examples`.
         :link: marking_routes
         :link-type: doc
 
-        Expose handlers with ``mcp_tool`` / ``mcp_resource`` kwargs or the
-        dedicated decorator.
+        Expose handlers with ``mcp_tool`` / ``mcp_resource`` /
+        ``mcp_prompt`` kwargs or the dedicated decorator.
 
-    .. grid-item-card:: Tools & Resources
-        :link: tools_and_resources
+    .. grid-item-card:: Prompts
+        :link: prompts
         :link-type: doc
 
-        How marked routes are registered, executed, and returned to MCP
-        clients.
+        Templated instructions exposed via ``prompts/list`` and
+        ``prompts/get``, including standalone and handler-based forms.
+
+    .. grid-item-card:: Resources
+        :link: resources
+        :link-type: doc
+
+        Read-only payloads served via ``resources/list`` and
+        ``resources/read``, with RFC 6570 URI template support.
+
+    .. grid-item-card:: Tools
+        :link: tools
+        :link-type: doc
+
+        Executable operations served via ``tools/list`` and
+        ``tools/call``, validated through Litestar signature models.
 
     .. grid-item-card:: Discovery
         :link: discovery
@@ -78,7 +92,9 @@ examples drawn from :mod:`docs.examples`.
 
     configuration
     marking_routes
-    tools_and_resources
+    prompts
+    resources
+    tools
     discovery
     auth
     framework_integration

--- a/docs/usage/marking_routes.rst
+++ b/docs/usage/marking_routes.rst
@@ -102,8 +102,13 @@ If you prefer a dedicated decorator over the kwargs form, ``litestar_mcp``
 ships :func:`~litestar_mcp.mcp_tool`, :func:`~litestar_mcp.mcp_resource`,
 and :func:`~litestar_mcp.mcp_prompt`. The tool and resource decorators
 carry the same metadata as the ``opt`` kwargs and are interchangeable at
-discovery time; ``mcp_prompt`` doubles as the marker for standalone
-prompt callables registered through ``LitestarMCP(prompts=[...])``.
+discovery time on a route handler.
+
+``mcp_prompt`` is different: the decorator and the ``mcp_prompt_*`` opt
+keys target *different registration paths*. Use the opt keys to expose a
+Litestar route handler as a prompt. Use the decorator to mark a plain
+callable that you hand to ``LitestarMCP(prompts=[...])``. The decorator
+does not act as the route-handler marker.
 
 .. tabs::
 

--- a/docs/usage/marking_routes.rst
+++ b/docs/usage/marking_routes.rst
@@ -4,7 +4,10 @@ Marking Routes
 
 Routes are exposed to MCP by attaching metadata to their ``opt`` dictionary.
 The plugin scans every handler at startup and treats any route tagged with
-``mcp_tool`` or ``mcp_resource`` as part of the MCP surface.
+``mcp_tool``, ``mcp_resource``, or ``mcp_prompt`` as part of the MCP surface.
+Standalone prompt callables that are *not* routed under HTTP are registered
+separately via ``LitestarMCP(prompts=[...])`` — see
+:ref:`Prompt Marker <usage/marking_routes:Prompt Marker>` below.
 
 Tool Marker
 ===========
@@ -34,6 +37,50 @@ expose it via ``resources/list`` and ``resources/read``.
     :end-before: # end-example
     :dedent:
 
+Prompt Marker
+=============
+
+Prompts are templated instructions for a model. The plugin recognises
+two registration paths.
+
+**Handler-based prompts.** Tag a Litestar route handler with
+``mcp_prompt="<prompt_name>"``. The handler stays a normal HTTP endpoint
+and is also reachable through ``prompts/get``. Override the description,
+title, argument list, or icons through dedicated opt keys:
+
+.. list-table::
+    :widths: 30 70
+    :header-rows: 1
+
+    * - Opt key
+      - Effect
+    * - ``mcp_prompt``
+      - Required. The prompt name used in ``prompts/get``.
+    * - ``mcp_prompt_description``
+      - LLM-facing description (falls back to the handler's docstring).
+    * - ``mcp_prompt_title``
+      - Optional human-readable title for UI clients.
+    * - ``mcp_prompt_arguments``
+      - Explicit argument list (a ``list[dict[str, Any]]``). When omitted,
+        the plugin introspects the handler's ``signature_model``, filters
+        out DI dependencies and framework-injected parameters
+        (``request``, ``headers``, ``state``, …), and enriches each entry
+        with Google-style docstring descriptions.
+    * - ``mcp_prompt_icons``
+      - Optional list of MCP icon objects (``src``, ``mimeType``, ``sizes``).
+
+**Standalone prompt functions.** Decorate a plain callable with
+:func:`~litestar_mcp.mcp_prompt` and pass it to
+``LitestarMCP(prompts=[...])``. These never appear in the HTTP route
+table — they are MCP-only.
+
+.. literalinclude:: /examples/snippets/marking_prompts.py
+    :language: python
+    :caption: ``docs/examples/snippets/marking_prompts.py``
+    :start-after: # start-example
+    :end-before: # end-example
+    :dedent:
+
 Dependency Injection
 ====================
 
@@ -52,9 +99,11 @@ Decorator Variant
 =================
 
 If you prefer a dedicated decorator over the kwargs form, ``litestar_mcp``
-ships :func:`~litestar_mcp.decorators.mcp_tool` and
-:func:`~litestar_mcp.decorators.mcp_resource`. Both carry the same metadata
-as the ``opt`` kwargs and are interchangeable at discovery time.
+ships :func:`~litestar_mcp.mcp_tool`, :func:`~litestar_mcp.mcp_resource`,
+and :func:`~litestar_mcp.mcp_prompt`. The tool and resource decorators
+carry the same metadata as the ``opt`` kwargs and are interchangeable at
+discovery time; ``mcp_prompt`` doubles as the marker for standalone
+prompt callables registered through ``LitestarMCP(prompts=[...])``.
 
 .. tabs::
 

--- a/docs/usage/prompts.rst
+++ b/docs/usage/prompts.rst
@@ -1,0 +1,82 @@
+=======
+Prompts
+=======
+
+Prompts are templated instructions for a model. Unlike tools (which
+execute) and resources (which return data), a prompt returns a list of
+messages the client feeds back into an LLM. The plugin supports two
+registration paths:
+
+* **Standalone prompt functions** — plain (async) callables decorated
+  with :func:`~litestar_mcp.mcp_prompt` and passed to
+  ``LitestarMCP(prompts=[...])``. These are not routed under HTTP; they
+  are reachable only through ``prompts/get``.
+* **Handler-based prompts** — Litestar route handlers tagged with
+  ``mcp_prompt="<name>"``. The handler stays a normal HTTP endpoint *and*
+  is published through ``prompts/get``, with full access to DI, guards,
+  and signature validation.
+
+The task-manager demo registers a single standalone prompt that
+summarises the current task list:
+
+.. literalinclude:: /examples/task_manager/main.py
+    :language: python
+    :caption: ``docs/examples/task_manager/main.py`` - ``register_prompts``
+    :pyobject: register_prompts
+
+See :doc:`marking_routes` for the handler-based opt-key form and the full
+``mcp_prompt*`` opt-key reference.
+
+Return Value Normalisation
+==========================
+
+A prompt's return value is normalised to a list of MCP ``PromptMessage``
+dicts before it goes on the wire:
+
+* ``str`` → single user-role text message.
+* ``dict`` with a ``role`` key and a recognised content block
+  (``text`` / ``image`` / ``audio`` / ``resource_link`` / ``resource``)
+  is wrapped in a list and used as-is.
+* ``list`` items follow the same dict rules.
+* Anything else is coerced to ``str(result)`` with a warning log.
+
+In practice this means the simplest possible prompt body — returning a
+single string — Just Works, and richer multi-message replies use the
+dict / list form. The advertised ``arguments`` list is derived from the
+function signature (or the handler's ``signature_model`` for the opt-key
+form), enriched with Google-style docstring descriptions when present.
+
+Capability Gating
+=================
+
+The ``prompts`` capability is only advertised — both in ``initialize``'s
+capability response and in ``/.well-known/mcp-server.json`` — when at
+least one visible prompt is registered. This matches the MCP spec's
+recommendation that servers only declare capabilities for primitives
+they actually expose. The same per-tag and per-operation include/exclude
+filters that gate tools and resources also gate prompt visibility.
+
+JSON-RPC Round-Trip
+===================
+
+After ``initialize``, clients drive prompts via ``prompts/list`` and
+``prompts/get``:
+
+.. code-block:: bash
+
+    # List every prompt the server publishes
+    curl -sS -X POST http://localhost:8000/mcp \
+      -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":1,"method":"prompts/list","params":{}}'
+
+    # Render a specific prompt (task-manager demo)
+    curl -sS -X POST http://localhost:8000/mcp \
+      -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":2,"method":"prompts/get",
+           "params":{"name":"summarize_tasks",
+                     "arguments":{"style":"detailed"}}}'
+
+A missing required argument surfaces as JSON-RPC ``INVALID_PARAMS``
+(``-32602``); an unknown argument name does the same — the executor
+validates the argument set against the handler's ``signature_model``
+before dispatch.

--- a/docs/usage/resources.rst
+++ b/docs/usage/resources.rst
@@ -51,8 +51,8 @@ JSON-RPC method, and concrete URIs flow through ``resources/read``:
 ``{var}`` matches a single non-empty path segment — it does NOT cross
 ``/``. Ambiguous templates resolve to the first-registered match. The
 ``completion/complete`` JSON-RPC method is available but returns an empty
-completion by default for 0.5.0; a ``@mcp_resource_completion`` decorator
-is planned for a future release.
+completion by default; user-supplied completion is planned but not yet
+exposed through a stable API.
 
 JSON-RPC Round-Trip
 ===================

--- a/docs/usage/resources.rst
+++ b/docs/usage/resources.rst
@@ -1,32 +1,12 @@
-====================
-Tools and Resources
-====================
+=========
+Resources
+=========
 
-Once marked, a route is ready to be called over MCP. This page walks
-through what registration looks like end-to-end, using the task-manager
-demo as a reference.
-
-Tool Registration
-=================
-
-Every ``mcp_tool`` handler becomes an entry in the plugin registry at
-startup. The task-manager demo registers five tool handlers covering the
-full CRUD lifecycle:
-
-.. literalinclude:: /examples/task_manager/main.py
-    :language: python
-    :caption: ``docs/examples/task_manager/main.py`` - ``register_tools``
-    :pyobject: register_tools
-
-The handlers themselves are ordinary Litestar ``@get`` / ``@post`` /
-``@delete`` callables - the only extra is the ``mcp_tool`` kwarg. Each tool
-is discoverable via ``tools/list`` and invocable via ``tools/call``.
-
-Resource Registration
-=====================
-
-Resources follow the same pattern with the ``mcp_resource`` kwarg. The
-same demo registers two read-only resources:
+Resources are read-only payloads such as schemas, capability summaries,
+or cached projections. Tag a Litestar route handler with
+``mcp_resource="<resource_name>"`` and the plugin publishes it via
+``resources/list`` and ``resources/read``. The task-manager demo
+registers two:
 
 .. literalinclude:: /examples/task_manager/main.py
     :language: python
@@ -38,7 +18,7 @@ Marked resources appear in ``resources/list`` and are fetched via
 ``litestar://openapi``, that returns the application's OpenAPI document.
 
 Resource URI Templates
-----------------------
+======================
 
 Pass ``mcp_resource_template="scheme://path/{var}"`` alongside
 ``mcp_resource`` to register an `RFC 6570 Level 1
@@ -77,36 +57,22 @@ is planned for a future release.
 JSON-RPC Round-Trip
 ===================
 
-The MCP Streamable HTTP transport is a single JSON-RPC endpoint at
-``/mcp``. Clients initialise once, then send ``tools/list``, ``tools/call``,
-``resources/list``, and ``resources/read`` methods:
+After ``initialize``, clients drive resources via ``resources/list`` and
+``resources/read``:
 
 .. code-block:: bash
 
-    # Initialise the server
+    # List every resource marked in the application
     curl -sS -X POST http://localhost:8000/mcp \
       -H "Content-Type: application/json" \
-      -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
-           "params":{"protocolVersion":"2025-11-25","capabilities":{},
-           "clientInfo":{"name":"curl","version":"1.0"}}}'
-
-    # List every tool marked in the application
-    curl -sS -X POST http://localhost:8000/mcp \
-      -H "Content-Type: application/json" \
-      -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
-
-    # Execute a specific tool (task-manager demo)
-    curl -sS -X POST http://localhost:8000/mcp \
-      -H "Content-Type: application/json" \
-      -d '{"jsonrpc":"2.0","id":3,"method":"tools/call",
-           "params":{"name":"list_tasks","arguments":{}}}'
+      -d '{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}'
 
     # Read a resource by URI
     curl -sS -X POST http://localhost:8000/mcp \
       -H "Content-Type: application/json" \
-      -d '{"jsonrpc":"2.0","id":4,"method":"resources/read",
+      -d '{"jsonrpc":"2.0","id":2,"method":"resources/read",
            "params":{"uri":"litestar://openapi"}}'
 
-Successful responses carry the handler's return value inside the standard
-JSON-RPC envelope. Errors raised from the underlying handler are mapped
-onto JSON-RPC error objects automatically.
+Successful responses carry the handler's return value inside the
+standard JSON-RPC envelope. Errors raised from the underlying handler
+are mapped onto JSON-RPC error objects automatically.

--- a/docs/usage/tools.rst
+++ b/docs/usage/tools.rst
@@ -1,0 +1,57 @@
+=====
+Tools
+=====
+
+Tools are executable operations — anything that takes arguments and
+returns structured output. Tag a Litestar route handler with
+``mcp_tool="<tool_name>"`` and the plugin publishes it via ``tools/list``
+and ``tools/call``. The task-manager demo registers five tool handlers
+covering the full CRUD lifecycle:
+
+.. literalinclude:: /examples/task_manager/main.py
+    :language: python
+    :caption: ``docs/examples/task_manager/main.py`` - ``register_tools``
+    :pyobject: register_tools
+
+The handlers themselves are ordinary Litestar ``@get`` / ``@post`` /
+``@delete`` callables — the only extra is the ``mcp_tool`` kwarg. Each
+tool is discoverable via ``tools/list`` and invocable via
+``tools/call``.
+
+Tool arguments are validated against the handler's ``signature_model``
+before dispatch — the same model Litestar uses for ordinary HTTP request
+parsing. Missing required arguments surface as JSON-RPC
+``INVALID_PARAMS`` (``-32602``). ``Annotated[T, Parameter(...)]`` query
+arguments are unwrapped and their ``Parameter`` constraints
+(``ge`` / ``le`` / ``min_length`` / ``pattern`` / …) flow through into
+the advertised ``inputSchema``.
+
+JSON-RPC Round-Trip
+===================
+
+After ``initialize``, clients drive tools via ``tools/list`` and
+``tools/call``:
+
+.. code-block:: bash
+
+    # Initialise the server
+    curl -sS -X POST http://localhost:8000/mcp \
+      -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":1,"method":"initialize",
+           "params":{"protocolVersion":"2025-11-25","capabilities":{},
+           "clientInfo":{"name":"curl","version":"1.0"}}}'
+
+    # List every tool marked in the application
+    curl -sS -X POST http://localhost:8000/mcp \
+      -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+
+    # Execute a specific tool (task-manager demo)
+    curl -sS -X POST http://localhost:8000/mcp \
+      -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":3,"method":"tools/call",
+           "params":{"name":"list_tasks","arguments":{}}}'
+
+Successful responses carry the handler's return value inside the
+standard JSON-RPC envelope. Errors raised from the underlying handler
+are mapped onto JSON-RPC error objects automatically.

--- a/tests/unit/test_usage_pages_present.py
+++ b/tests/unit/test_usage_pages_present.py
@@ -1,7 +1,10 @@
 """Structural test for the usage-guide-rewrite restructure.
 
-Guards the six focused ``docs/usage/`` pages that replace the original
+Guards the focused ``docs/usage/`` pages that replace the original
 flat structure (`configuration.rst`, `marking-routes.rst`, `examples.rst`).
+
+The MCP usage primitives (tools, resources, prompts) are documented on
+separate pages to mirror the MCP specification.
 
 If any of these pages disappear, the literalinclude-backed docs grid will
 regress.
@@ -18,7 +21,9 @@ USAGE_DIR = Path(__file__).resolve().parents[2] / "docs" / "usage"
 EXPECTED_PAGES = (
     "configuration.rst",
     "marking_routes.rst",
-    "tools_and_resources.rst",
+    "tools.rst",
+    "resources.rst",
+    "prompts.rst",
     "discovery.rst",
     "auth.rst",
     "framework_integration.rst",


### PR DESCRIPTION
## Summary

Documents the MCP Prompts feature shipped in #46 across the usage guide, API reference, README, and task-manager example. Splits the legacy "Tools and Resources" page into three spec-aligned pages — Prompts, Resources, Tools — mirroring the [MCP 2025-11-25 server-features structure](https://modelcontextprotocol.io/specification/2025-11-25/server).

Closes #56.

## What changed

**Usage guide**
- New `prompts.rst` / `resources.rst` / `tools.rst` (replaces `tools_and_resources.rst`); each page is self-contained with its own JSON-RPC round-trip example.
- `marking_routes.rst` documents `mcp_prompt` and the five `mcp_prompt_*` opt keys, plus the dual handler-based / standalone registration paths.
- `configuration.rst` documents `LitestarMCP(prompts=[...])` with a new snippet.
- `discovery.rst` notes the conditional `prompts` capability gating in `/.well-known/mcp-server.json`.
- `usage/index.rst` grid + toctree updated to MCP spec order (Prompts → Resources → Tools).

**API reference**
- `handlers.rst` retitled "Handlers and Decorators"; exposes `mcp_tool` / `mcp_resource` / `mcp_prompt` (the first two were also missing).
- `config.rst` documents `MCPOptKeys`.
- `types.rst` documents `PromptRegistration` with a cross-link to `MCPOptKeys`.
- `plugin.rst` prose updated.

**Examples**
- `docs/examples/task_manager/main.py` gains `register_prompts()` with a `summarize_tasks` standalone prompt (closure-bound to the task store, mirroring `register_tools` / `register_resources`).
- `test_task_manager.py` gains `prompts/list` and `prompts/get` round-trip tests.
- New snippets: `marking_prompts.py` (both registration paths in one app), `configuration_prompts.py` (standalone form).

**README**
- Lead paragraph and Features list mention prompts; opt-key examples updated.

## Test plan

- [x] `make docs` — clean build, no new warnings introduced. The pre-existing `MCPConfig` duplicate-object-description warnings are not touched.
- [x] `pytest tests/unit/test_prompts.py docs/examples/task_manager/ docs/examples/snippets/test_snippets.py` — 117 passed, including the two new task-manager prompt tests.
- [x] Snippet smoke test auto-discovers `marking_prompts.py` and `configuration_prompts.py` via `pkgutil.iter_modules` — both build a valid `Litestar` app.

## Notes

- The `Annotated[T, Parameter(...)]` schema fix (#52 / #53) docs gap is mentioned in #56 as out-of-scope and is not addressed here. Happy to file a follow-up issue if useful.
- File rename from `tools_and_resources.rst` to three new files breaks the old slug. The only internal reference was `docs/usage/index.rst`, which is updated. Generated `_build/` artefacts regenerate.