### PR TITLE
docs: fix broken project URLs in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,13 @@ requires-python = ">=3.10"
 version = "0.7.0"
 
 [project.urls]
-Changelog = "https://docs.litestar-mcp.litestar.dev/latest/changelog"
+Changelog = "https://cofin.github.io/litestar-mcp/latest/changelog"
 Discord = "https://discord.gg/litestar"
-Documentation = "https://docs.litestar-mcp.litestar.dev/latest/"
+Documentation = "https://cofin.github.io/litestar-mcp/latest/"
 Funding = "https://github.com/sponsors/litestar-org"
-Homepage = "https://docs.litestar-mcp.litestar.dev/latest/"
-Issue = "https://github.com/litestar-org/litestar-mcp/issues/"
-Source = "https://github.com/litestar-org/litestar-mcp"
+Homepage = "https://cofin.github.io/litestar-mcp/latest/"
+Issue = "https://github.com/cofin/litestar-mcp/issues/"
+Source = "https://github.com/cofin/litestar-mcp"
 
 [project.entry-points."pygments.styles"]
 litestar-mcp-dark = "tools.sphinx_ext.pygments_styles:LitestarMcpDarkStyle"


### PR DESCRIPTION
## Summary

- Replace `docs.litestar-mcp.litestar.dev` (DNS does not resolve) with the live GitHub Pages docs site `cofin.github.io/litestar-mcp/latest/` for `Documentation`, `Homepage`, and `Changelog`.
- Point `Source` and `Issue` at `github.com/cofin/litestar-mcp` (the previous `litestar-org/litestar-mcp` paths 404).

These URLs are surfaced on PyPI as the project's official links, so the broken values were user-visible on every release.

Closes #59

## Test plan

- [x] `curl -sIL https://cofin.github.io/litestar-mcp/latest/` → 200
- [x] `curl -sIL https://cofin.github.io/litestar-mcp/latest/changelog` → 200
- [x] `curl -sIL https://github.com/cofin/litestar-mcp` → 200