### PR TITLE
fix(routes): align streamable responses and filters

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,43 +2,216 @@
 Changelog
 =========
 
-All notable changes to this project will be documented in this file.
+All notable Litestar MCP changes are summarized here. Entries are grouped by
+release and focus on user-visible behavior, public API changes, compatibility
+notes, and important protocol fixes.
 
-The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.0.0/>`_,
-and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
+Recent Updates
+==============
 
-Unreleased
-----------
+.. changelog:: 0.7.1
+    :date: 2026-06-09
 
-Changed
-~~~~~~~
+    .. change:: fix published project URLs
+        :type: bugfix
+        :pr: 60
 
-- Switched the transport surface to MCP Streamable HTTP with ``GET /mcp`` for SSE and ``POST /mcp`` for JSON-RPC requests.
-- Added well-known discovery documents for MCP clients and agent metadata.
-- Raised the supported Python floor to 3.10.
-- Renamed the bundled example directories from ``docs/examples/basic/`` and
-  ``docs/examples/advanced/`` to ``docs/examples/hello_world/`` and
-  ``docs/examples/task_manager/``. Each example now ships with a sibling
-  pytest module and ``# start-example`` / ``# end-example`` marker blocks so
-  the usage guide can pull snippets via ``.. literalinclude:: :dedent: 4``.
-  No compatibility shim is provided - update any external references to use
-  the new paths.
+        Corrects package metadata links so the project URL points at the GitHub
+        repository and the documentation URL points at the published docs site.
 
-Removed
-~~~~~~~
+    .. change:: return 202 for accepted Streamable HTTP notifications
+        :type: bugfix
+        :issue: 61
 
-- Removed the legacy REST MCP endpoints and session-oriented transport surface.
+        Accepted JSON-RPC notifications over MCP Streamable HTTP now return
+        ``202 Accepted`` with an empty body, matching the MCP transport
+        requirement for accepted JSON-RPC notifications and responses sent via
+        POST.
 
-v0.1.0 (2025-01-04)
--------------------
+    .. change:: apply filters to direct tool and resource invocation
+        :type: bugfix
+        :issue: 62
 
-Added
-~~~~~
+        ``include_*`` and ``exclude_*`` filters now gate direct ``tools/call``
+        and ``resources/read`` invocation in addition to list responses. A
+        filtered tool, resource, or resource template is treated like an
+        unknown name or URI. Filters narrow the MCP exposure surface; Litestar
+        guards and auth middleware remain the access-control boundary.
 
-- Initial implementation of the Litestar MCP Plugin
-- Route marking using ``mcp_tool`` and ``mcp_resource`` kwargs
-- Automatic discovery of marked routes via opt dictionary scanning
-- REST-based MCP endpoints (``/mcp/``, ``/mcp/tools``, ``/mcp/resources``)
-- OpenAPI schema integration and exposure as MCP resource
-- Minimal configuration with ``MCPConfig`` class
-- Support for both tools (executable functions) and resources (read-only data)
+
+.. changelog:: 0.7.0
+    :date: 2026-06-07
+
+    .. change:: paginate MCP list methods
+        :type: feature
+        :pr: 58
+        :issue: 47
+
+        Adds opaque cursor pagination for MCP list methods so clients can page
+        through tools, resources, resource templates, and prompts using
+        ``nextCursor``.
+
+    .. change:: converge handler signature introspection
+        :type: bugfix
+        :pr: 58
+        :issue: 49
+
+        Uses the same handler-signature introspection path for schema
+        generation and execution-time argument handling, reducing drift between
+        advertised input schemas and accepted call arguments.
+
+    .. change:: document the MCP primitive error contract
+        :type: bugfix
+        :pr: 58
+        :issue: 48
+
+        Locks and documents the primitive-level error contract for tools,
+        resources, and prompts. Handler HTTP status is preserved in error data
+        where relevant instead of minting non-standard JSON-RPC codes.
+
+    .. change:: document MCP Prompts end-to-end
+        :type: misc
+        :pr: 58
+        :issue: 56
+
+        Adds Prompts coverage across the usage guide, API reference, README,
+        and task-manager example.
+
+
+.. changelog:: 0.6.0
+    :date: 2026-06-04
+
+    .. change:: add MCP Prompts support
+        :type: feature
+        :pr: 46
+
+        Adds MCP Prompts support, including prompt discovery and retrieval via
+        ``prompts/list`` and ``prompts/get``.
+
+    .. change:: update for Litestar 3 deprecations
+        :type: misc
+        :pr: 54
+
+        Updates runtime, docs, and tests for Litestar 3 deprecation paths.
+
+    .. change:: unwrap Annotated parameters in input schemas
+        :type: bugfix
+        :pr: 53
+        :issue: 52
+
+        Unwraps ``Annotated[T, Parameter(...)]`` declarations when generating
+        MCP tool input schemas so Litestar parameter metadata does not hide the
+        underlying value type.
+
+
+.. changelog:: 0.5.1
+    :date: 2026-04-19
+
+    .. change:: restore full Litestar execution parity
+        :type: bugfix
+        :pr: 44
+        :issue: 41 42 43
+
+        Runs MCP tool execution through the full Litestar request lifecycle for
+        hooks, renamed fields, and path-parameter coercion.
+
+
+.. changelog:: 0.5.0
+    :date: 2026-04-19
+
+    .. change:: add consumer-readiness features
+        :type: feature
+        :pr: 40
+
+        Adds structured tool/resource descriptions, resource templates,
+        ``resources/templates/list``, ``completion/complete``, injectable JWKS
+        cache support, and well-known discovery documents.
+
+    .. change:: refresh docs and examples for consumer usage
+        :type: misc
+        :pr: 40
+
+        Raises the supported Python floor to 3.10, renames bundled examples to
+        ``hello_world`` and ``task_manager``, adds example tests and snippet
+        markers, and updates docs to prefer Litestar route kwargs such as
+        ``mcp_tool="name"``.
+
+    .. change:: remove scope enforcement and auth extra
+        :type: misc
+        :breaking:
+        :pr: 40
+
+        Removes inline scope enforcement so scopes are discovery metadata and
+        Litestar guards are the access-control surface. The legacy auth extra
+        was removed and auth dependencies now install with the core package.
+
+
+.. changelog:: 0.4.0
+    :date: 2026-04-16
+
+    .. change:: switch to Streamable HTTP
+        :type: feature
+        :pr: 32
+
+        Replaces the legacy REST endpoint surface with MCP Streamable HTTP,
+        using ``GET /mcp`` for SSE and ``POST /mcp`` for JSON-RPC requests.
+
+    .. change:: add database integration test matrix
+        :type: misc
+        :pr: 34
+
+        Adds database-backed integration coverage for Advanced Alchemy,
+        SQLSpec, Dishka, and auth-mode combinations.
+
+
+.. changelog:: 0.3.0
+    :date: 2026-03-22
+
+    .. change:: align with MCP JSON-RPC, transport, and auth specs
+        :type: feature
+        :pr: 13
+
+        Adds MCP spec compliance for JSON-RPC 2.0, Streamable HTTP, and OAuth
+        auth bridging.
+
+
+.. changelog:: 0.2.2
+    :date: 2025-09-30
+
+    .. change:: remove duplicate CLI pass_context decorator
+        :type: bugfix
+        :pr: 6
+
+        Removes a duplicate ``pass_context`` decorator from CLI commands.
+
+
+.. changelog:: 0.2.1
+    :date: 2025-09-28
+
+    .. change:: add Litestar CLI plugin integration
+        :type: feature
+        :pr: 5
+
+        Implements Litestar CLI plugin integration.
+
+
+.. changelog:: 0.2.0
+    :date: 2025-09-27
+
+    .. change:: add CLI interface
+        :type: feature
+        :pr: 4
+
+        Adds the initial command-line interface.
+
+
+.. changelog:: 0.1.0
+    :date: 2025-09-06
+
+    .. change:: initial release
+        :type: feature
+
+        Adds the initial Litestar MCP plugin with route marking via
+        ``mcp_tool`` and ``mcp_resource`` kwargs, automatic route discovery,
+        REST-based MCP endpoints, OpenAPI schema exposure, ``MCPConfig``, and
+        support for tools and resources.

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -124,6 +124,13 @@ The ``LitestarMCP`` constructor also accepts a top-level ``prompts``
 argument — a sequence of ``@mcp_prompt``-decorated callables — for
 standalone prompt registration (see above).
 
+Filters apply both to list responses and direct invocation. A filtered tool
+or resource is omitted from ``tools/list``, ``resources/list``, or
+``resources/templates/list`` and a direct ``tools/call`` / ``resources/read``
+returns the same not-found response as an unknown name or URI. Filters narrow
+the MCP exposure surface; use ``guards`` or auth middleware for access
+control.
+
 List Pagination
 ===============
 

--- a/docs/usage/framework_integration.rst
+++ b/docs/usage/framework_integration.rst
@@ -66,7 +66,10 @@ Filtering Exposure
 
 Use the ``include_tags`` / ``exclude_tags`` and
 ``include_operations`` / ``exclude_operations`` options to restrict which
-marked handlers are visible. Filters apply at ``tools/list`` and
-``resources/list`` time - a handler hidden by a filter is simply not
-returned, but may still be invoked directly if the caller knows its name.
-Precedence is ``exclude > include`` and ``tags > operations``.
+marked handlers are exposed. Filters apply to ``tools/list``,
+``resources/list``, ``resources/templates/list``, direct ``tools/call``,
+and direct ``resources/read``. A filtered handler is omitted from list
+responses and direct invocation returns the same not-found response as an
+unknown name or URI. Precedence is ``exclude > include`` and
+``tags > operations``. Filters are not authentication; use MCP router
+``guards`` or auth middleware for access control.

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -17,6 +17,7 @@ from litestar.response import ServerSentEvent, ServerSentEventMessage
 from litestar.serialization import decode_json, encode_json
 from litestar.status_codes import (
     HTTP_200_OK,
+    HTTP_202_ACCEPTED,
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
@@ -488,6 +489,9 @@ def build_jsonrpc_router(
         handler = discovered_tools.get(tool_name)
         if handler is None:
             raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message=f"Tool not found: {tool_name}"))
+        handler_tags = set(getattr(handler, "tags", None) or [])
+        if not should_include_handler(tool_name, handler_tags, config):
+            raise JSONRPCErrorException(JSONRPCError(code=INVALID_PARAMS, message=f"Tool not found: {tool_name}"))
 
         fn = get_handler_function(handler)
         metadata = get_mcp_metadata(handler) or get_mcp_metadata(fn) or {}
@@ -612,6 +616,9 @@ def build_jsonrpc_router(
             handler = discovered_resources.get(resource_name)
             if handler is None:
                 raise JSONRPCErrorException(mcp_error_for_resource_not_found(uri))
+            handler_tags = set(getattr(handler, "tags", None) or [])
+            if not should_include_handler(resource_name, handler_tags, config):
+                raise JSONRPCErrorException(mcp_error_for_resource_not_found(uri))
 
             try:
                 result = await execute_tool(
@@ -641,6 +648,9 @@ def build_jsonrpc_router(
         for entry in template_entries:
             extracted = match_uri(entry.template, uri)
             if extracted is None:
+                continue
+            handler_tags = set(getattr(entry.handler, "tags", None) or [])
+            if not should_include_handler(entry.name, handler_tags, config):
                 continue
             try:
                 result = await execute_tool(
@@ -1119,7 +1129,7 @@ class MCPController(Controller):
 
         response: Response[Any]
         if result is None:
-            response = Response(content=None, status_code=HTTP_204_NO_CONTENT)
+            response = Response(content=b"", status_code=HTTP_202_ACCEPTED)
         else:
             response = Response(content=result, status_code=HTTP_200_OK, media_type=MediaType.JSON)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ maintainers = [
 name = "litestar-mcp"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.7.0"
+version = "0.7.1"
 
 [project.urls]
 Changelog = "https://cofin.github.io/litestar-mcp/latest/changelog"
@@ -116,7 +116,7 @@ test = [
 allow_dirty = true
 commit = false
 commit_args = "--no-verify"
-current_version = "0.7.0"
+current_version = "0.7.1"
 ignore_missing_files = false
 ignore_missing_version = false
 message = "chore(release): bump to v{new_version}"

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -145,3 +145,85 @@ class TestFilteringIntegration:
         tool_names = [t["name"] for t in result["result"]["tools"]]
         assert "tool_a" in tool_names
         assert "tool_b" not in tool_names
+
+    def test_include_operations_filters_tools_call(self) -> None:
+        @get("/public", mcp_tool="public_tool", sync_to_thread=False)
+        def public_tool() -> str:
+            """Public tool."""
+            return "public"
+
+        @get("/secret", mcp_tool="secret_tool", sync_to_thread=False)
+        def secret_tool() -> str:
+            """Secret tool."""
+            return "secret"
+
+        config = MCPConfig(include_operations=["public_tool"])
+        app = Litestar(route_handlers=[public_tool, secret_tool], plugins=[LitestarMCP(config)])
+        client = TestClient(app=app)
+
+        result = _rpc(client, "tools/list")
+        tool_names = [t["name"] for t in result["result"]["tools"]]
+        assert "public_tool" in tool_names
+        assert "secret_tool" not in tool_names
+
+        call_result = _rpc(client, "tools/call", {"name": "secret_tool", "arguments": {}})
+        assert call_result["error"]["code"] == -32602
+        assert call_result["error"]["message"] == "Tool not found: secret_tool"
+
+    def test_exclude_tags_filters_resource_read(self) -> None:
+        @get("/public-resource", mcp_resource="public_resource", tags=["public"], sync_to_thread=False)
+        def public_resource() -> dict[str, str]:
+            return {"scope": "public"}
+
+        @get("/secret-resource", mcp_resource="secret_resource", tags=["internal"], sync_to_thread=False)
+        def secret_resource() -> dict[str, str]:
+            return {"scope": "secret"}
+
+        config = MCPConfig(exclude_tags=["internal"])
+        app = Litestar(route_handlers=[public_resource, secret_resource], plugins=[LitestarMCP(config)])
+        client = TestClient(app=app)
+
+        result = _rpc(client, "resources/list")
+        resource_names = [r["name"] for r in result["result"]["resources"]]
+        assert "public_resource" in resource_names
+        assert "secret_resource" not in resource_names
+
+        read_result = _rpc(client, "resources/read", {"uri": "litestar://secret_resource"})
+        assert read_result["error"]["code"] == -32002
+        assert read_result["error"]["message"] == "Resource not found"
+        assert read_result["error"]["data"] == {"uri": "litestar://secret_resource"}
+
+    def test_exclude_tags_filters_resource_template_read(self) -> None:
+        @get(
+            "/public-template/{item_id:int}",
+            mcp_resource="public_template",
+            mcp_resource_template="app://public/{item_id}",
+            tags=["public"],
+            sync_to_thread=False,
+        )
+        def public_template(item_id: int) -> dict[str, int]:
+            return {"item_id": item_id}
+
+        @get(
+            "/secret-template/{item_id:int}",
+            mcp_resource="secret_template",
+            mcp_resource_template="app://secret/{item_id}",
+            tags=["internal"],
+            sync_to_thread=False,
+        )
+        def secret_template(item_id: int) -> dict[str, int]:
+            return {"item_id": item_id}
+
+        config = MCPConfig(exclude_tags=["internal"])
+        app = Litestar(route_handlers=[public_template, secret_template], plugins=[LitestarMCP(config)])
+        client = TestClient(app=app)
+
+        result = _rpc(client, "resources/templates/list")
+        template_names = [r["name"] for r in result["result"]["resourceTemplates"]]
+        assert "public_template" in template_names
+        assert "secret_template" not in template_names
+
+        read_result = _rpc(client, "resources/read", {"uri": "app://secret/1"})
+        assert read_result["error"]["code"] == -32002
+        assert read_result["error"]["message"] == "Resource not found"
+        assert read_result["error"]["data"] == {"uri": "app://secret/1"}

--- a/tests/unit/test_jsonrpc.py
+++ b/tests/unit/test_jsonrpc.py
@@ -438,12 +438,12 @@ class TestErrorHandling:
 
 class TestNotifications:
     def test_notifications_initialized_no_response(self, client: TestClient[Any]) -> None:
-        """notifications/initialized is a notification (no id) — server should return 204."""
+        """notifications/initialized is accepted with 202 and no response body."""
         sid = _ensure_session(client)
         body = {"jsonrpc": "2.0", "method": "notifications/initialized"}
         resp = client.post("/mcp", json=body, headers={"Mcp-Session-Id": sid})
-        # Notifications get no response body per JSON-RPC spec
-        assert resp.status_code in (200, 202, 204)
+        assert resp.status_code == 202
+        assert resp.content == b""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_transport.py
+++ b/tests/unit/test_transport.py
@@ -85,13 +85,14 @@ def test_full_post_only_flow() -> None:
         )
         session_id = init.headers["mcp-session-id"]
 
-        # notifications/initialized (notification: no id)
+        # notifications/initialized (accepted notification: 202, no body)
         notif = client.post(
             "/mcp",
             json={"jsonrpc": "2.0", "method": "notifications/initialized"},
             headers={"Mcp-Session-Id": session_id},
         )
-        assert notif.status_code in {200, 204}
+        assert notif.status_code == 202
+        assert notif.content == b""
 
         # tools/list with session header should succeed
         listed = _rpc(client, "tools/list", headers={"Mcp-Session-Id": session_id})

--- a/tools/sphinx_ext/changelog.py
+++ b/tools/sphinx_ext/changelog.py
@@ -11,7 +11,7 @@ from sphinx.util.nodes import clean_astext
 if TYPE_CHECKING:
     from sphinx.domains.std import StandardDomain
 
-_GH_BASE_URL = "https://github.com/litestar-org/advanced-alchemy"
+_GH_BASE_URL = "https://github.com/cofin/litestar-mcp"
 
 
 def _parse_gh_reference(raw: str, type_: Literal["issues", "pull"]) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -890,7 +890,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1471,7 +1471,7 @@ wheels = [
 
 [[package]]
 name = "litestar-mcp"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Return `202 Accepted` with an empty body for accepted Streamable HTTP JSON-RPC notifications/responses, matching the MCP transport requirement.
- Apply `include_*` / `exclude_*` filters to direct `tools/call` and `resources/read` invocation, including resource templates, so filtered handlers are treated like missing names or URIs.
- Backfill the changelog into release-grouped entries with no `Unreleased` section, keep the `0.7.1` version bump, and update the changelog GitHub reference URL.

## Protocol validation
- #61 is a direct MCP Streamable HTTP transport compliance fix: accepted JSON-RPC notifications/responses sent via POST return HTTP 202 with no body.
- #62 is an exposure-contract/interoperability fix: the protocol list methods define the advertised MCP surface, so handlers hidden by filters should not remain callable/readable by direct primitive requests. Filters are still not treated as auth; Litestar guards and auth middleware remain the access-control boundary.

## Validation
- `uv run --frozen pytest -q tests/unit/test_jsonrpc.py::TestNotifications::test_notifications_initialized_no_response tests/unit/test_filters.py::TestFilteringIntegration::test_include_operations_filters_tools_call tests/unit/test_filters.py::TestFilteringIntegration::test_exclude_tags_filters_resource_read tests/unit/test_filters.py::TestFilteringIntegration::test_exclude_tags_filters_resource_template_read --no-cov`
- `uv run --frozen pytest -q tests/unit/test_jsonrpc.py tests/unit/test_filters.py --no-cov`
- `env UV_FROZEN=1 UV_LINK_MODE=copy make lint`
- `env UV_FROZEN=1 UV_LINK_MODE=copy make test`
- `env UV_FROZEN=1 UV_LINK_MODE=copy make docs`
- `uv lock --check`

Fixes #61.
Fixes #62.