### PR TITLE
fix(schema): surface provider-declared query params in MCP inputSchema

### DIFF
--- a/litestar_mcp/cli.py
+++ b/litestar_mcp/cli.py
@@ -25,6 +25,40 @@ if TYPE_CHECKING:
     from litestar_mcp.plugin import LitestarMCP
 
 
+def _append_cli_option(
+    params: "list[click.Option]",
+    seen: set[str],
+    name: str,
+    param: inspect.Parameter,
+) -> None:
+    """Append a ``click.Option`` derived from a handler/provider parameter.
+
+    Deduplicates on ``name`` so handler-sig and provider-walk passes can both
+    feed the same accumulator without double-emitting the same flag.
+    """
+    if name in seen:
+        return
+    seen.add(name)
+    annotation = param.annotation
+    is_json = (
+        annotation in {dict, list, set}
+        or hasattr(annotation, "__origin__")
+        or (hasattr(annotation, "__module__") and annotation.__module__ != "builtins")
+    )
+    help_text = f"Type: {getattr(annotation, '__name__', str(annotation))}"
+    if is_json:
+        help_text += ". Pass as JSON string if complex type."
+    option_kwargs: dict[str, Any] = {
+        "help": help_text,
+        "required": param.default is inspect.Parameter.empty,
+    }
+    if annotation is bool and param.default is not inspect.Parameter.empty:
+        option_kwargs["is_flag"] = True
+        option_kwargs["default"] = param.default
+        option_kwargs.pop("required", None)
+    params.append(click.Option([f"--{name}"], **option_kwargs))  # pyright: ignore
+
+
 def get_mcp_plugin(app: "Litestar") -> "LitestarMCP":
     """Retrieve the MCP plugin from the Litestar application's plugins.
 
@@ -88,41 +122,14 @@ class ToolExecutor(click.MultiCommand):  # type: ignore[valid-type,misc,unused-i
             di_params = set(handler.resolve_dependencies().keys())
 
         # Create CLI options from function signature + provider params.
-        params = []
-        seen_param_names: set[str] = set()
-
-        def _add_option(name: str, param: inspect.Parameter) -> None:
-            if name in seen_param_names:
-                return
-            seen_param_names.add(name)
-            annotation = param.annotation
-            is_json = (
-                annotation in {dict, list, set}
-                or hasattr(annotation, "__origin__")
-                or (hasattr(annotation, "__module__") and annotation.__module__ != "builtins")
-            )
-            help_text = f"Type: {getattr(annotation, '__name__', str(annotation))}"
-            if is_json:
-                help_text += ". Pass as JSON string if complex type."
-
-            option_kwargs: dict[str, Any] = {
-                "help": help_text,
-                "required": param.default is inspect.Parameter.empty,
-            }
-            if annotation is bool and param.default is not inspect.Parameter.empty:
-                option_kwargs["is_flag"] = True
-                option_kwargs["default"] = param.default
-                option_kwargs.pop("required", None)
-
-            params.append(click.Option([f"--{name}"], **option_kwargs))  # pyright: ignore
-
+        params: list[click.Option] = []
+        seen: set[str] = set()
         for param in sig.parameters.values():
             if param.name in di_params:
                 continue
-            _add_option(param.name, param)
-
+            _append_cli_option(params, seen, param.name, param)
         for name, param in iter_dependency_input_parameters(handler):
-            _add_option(name, param)
+            _append_cli_option(params, seen, name, param)
 
         @click.pass_context
         def callback(ctx: click.Context, /, **kwargs: Any) -> None:

--- a/litestar_mcp/cli.py
+++ b/litestar_mcp/cli.py
@@ -11,6 +11,7 @@ from rich.console import Console
 from rich.json import JSON
 
 from litestar_mcp.executor import NotCallableInCLIContextError, execute_tool
+from litestar_mcp.schema_builder import iter_dependency_input_parameters
 from litestar_mcp.utils import get_handler_function, render_description
 
 try:
@@ -86,20 +87,20 @@ class ToolExecutor(click.MultiCommand):  # type: ignore[valid-type,misc,unused-i
         with contextlib.suppress(Exception):
             di_params = set(handler.resolve_dependencies().keys())
 
-        # Create CLI options from function signature
+        # Create CLI options from function signature + provider params.
         params = []
-        for param in sig.parameters.values():
-            if param.name in di_params:
-                continue
+        seen_param_names: set[str] = set()
 
-            # For complex types, accept a JSON string
+        def _add_option(name: str, param: inspect.Parameter) -> None:
+            if name in seen_param_names:
+                return
+            seen_param_names.add(name)
             annotation = param.annotation
             is_json = (
                 annotation in {dict, list, set}
                 or hasattr(annotation, "__origin__")
                 or (hasattr(annotation, "__module__") and annotation.__module__ != "builtins")
             )
-
             help_text = f"Type: {getattr(annotation, '__name__', str(annotation))}"
             if is_json:
                 help_text += ". Pass as JSON string if complex type."
@@ -108,14 +109,20 @@ class ToolExecutor(click.MultiCommand):  # type: ignore[valid-type,misc,unused-i
                 "help": help_text,
                 "required": param.default is inspect.Parameter.empty,
             }
-
-            # For boolean parameters with defaults, create flags instead of options
             if annotation is bool and param.default is not inspect.Parameter.empty:
                 option_kwargs["is_flag"] = True
                 option_kwargs["default"] = param.default
-                option_kwargs.pop("required", None)  # Flags can't be required
+                option_kwargs.pop("required", None)
 
-            params.append(click.Option([f"--{param.name}"], **option_kwargs))  # pyright: ignore
+            params.append(click.Option([f"--{name}"], **option_kwargs))  # pyright: ignore
+
+        for param in sig.parameters.values():
+            if param.name in di_params:
+                continue
+            _add_option(param.name, param)
+
+        for name, param in iter_dependency_input_parameters(handler):
+            _add_option(name, param)
 
         @click.pass_context
         def callback(ctx: click.Context, /, **kwargs: Any) -> None:

--- a/litestar_mcp/executor.py
+++ b/litestar_mcp/executor.py
@@ -35,7 +35,7 @@ from litestar.response import Response
 from litestar.types.empty import Empty
 from litestar.utils.sync import ensure_async_callable
 
-from litestar_mcp.schema_builder import parameter_aliases
+from litestar_mcp.schema_builder import iter_dependency_input_parameters, parameter_aliases
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -427,6 +427,9 @@ def _split_tool_args(
     sig_params = handler.parsed_fn_signature.parameters
     has_data = "data" in sig_params
     scalar_sig_names = {name for name in sig_params if name != "data"}
+    # Provider-declared query/path params bubble up to the route through
+    # Litestar's DI inheritance, so the MCP wire surface accepts them too.
+    scalar_sig_names.update(name for name, _ in iter_dependency_input_parameters(handler))
 
     # Build a set of wire keys that resolve to scalar sig params via aliases
     # (or directly when no alias exists).  Keeps wire names in query_payload so

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -325,13 +325,14 @@ def _validate_tool_arguments(handler: "BaseRouteHandler", tool_args: dict[str, A
             display_name = python_to_wire.get(name, name)
             errors.append({"path": "/arguments", "message": f"Unexpected argument: {display_name}"})
             continue
-        declared = declared_by_name.get(name)
         # Provider-declared params won't appear in ``parsed_fn_signature``;
         # fall back to the advertised parameter's annotation in that case.
-        fallback_annotation = getattr(advertised_by_name[name], "annotation", Any)
-        convert_type = annotated_types.get(
-            name, getattr(declared, "annotation", fallback_annotation) if declared is not None else fallback_annotation
-        )
+        declared = declared_by_name.get(name)
+        if declared is not None:
+            default_annotation = getattr(declared, "annotation", Any)
+        else:
+            default_annotation = getattr(advertised_by_name[name], "annotation", Any)
+        convert_type = annotated_types.get(name, default_annotation)
         try:
             msgspec.convert(value, convert_type, strict=False)
         except msgspec.ValidationError as exc:

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -325,8 +325,13 @@ def _validate_tool_arguments(handler: "BaseRouteHandler", tool_args: dict[str, A
             display_name = python_to_wire.get(name, name)
             errors.append({"path": "/arguments", "message": f"Unexpected argument: {display_name}"})
             continue
-        declared = declared_by_name[name]
-        convert_type = annotated_types.get(name, getattr(declared, "annotation", Any))
+        declared = declared_by_name.get(name)
+        # Provider-declared params won't appear in ``parsed_fn_signature``;
+        # fall back to the advertised parameter's annotation in that case.
+        fallback_annotation = getattr(advertised_by_name[name], "annotation", Any)
+        convert_type = annotated_types.get(
+            name, getattr(declared, "annotation", fallback_annotation) if declared is not None else fallback_annotation
+        )
         try:
             msgspec.convert(value, convert_type, strict=False)
         except msgspec.ValidationError as exc:

--- a/litestar_mcp/routes.py
+++ b/litestar_mcp/routes.py
@@ -54,7 +54,7 @@ from litestar_mcp.registry import (
     resolve_prompt_description,
     should_include_prompt,
 )
-from litestar_mcp.schema_builder import generate_schema_for_handler, parameter_aliases
+from litestar_mcp.schema_builder import _unwrap_annotated, generate_schema_for_handler, parameter_aliases
 from litestar_mcp.sessions import MCPSessionManager, SessionTerminated
 from litestar_mcp.sse import StreamLimitExceeded
 from litestar_mcp.tasks import InMemoryTaskStore, TaskLookupError, TaskRecord, TaskStateError
@@ -327,11 +327,17 @@ def _validate_tool_arguments(handler: "BaseRouteHandler", tool_args: dict[str, A
             continue
         # Provider-declared params won't appear in ``parsed_fn_signature``;
         # fall back to the advertised parameter's annotation in that case.
+        # The advertised annotation is the raw ``inspect.Parameter.annotation``
+        # which may still be wrapped in ``Annotated[..., ParameterKwarg(...)]``;
+        # ``msgspec.convert`` rejects Litestar's ``ParameterKwarg`` metadata, so
+        # peel it to the inner type before validation.
         declared = declared_by_name.get(name)
         if declared is not None:
             default_annotation = getattr(declared, "annotation", Any)
         else:
-            default_annotation = getattr(advertised_by_name[name], "annotation", Any)
+            raw = getattr(advertised_by_name[name], "annotation", Any)
+            inner, _ = _unwrap_annotated(raw)
+            default_annotation = inner
         convert_type = annotated_types.get(name, default_annotation)
         try:
             msgspec.convert(value, convert_type, strict=False)

--- a/litestar_mcp/schema_builder.py
+++ b/litestar_mcp/schema_builder.py
@@ -174,9 +174,16 @@ def iter_dependency_input_parameters(
             if pname in seen_names:
                 continue
             seen_names.add(pname)
-            resolved = resolved_hints.get(pname)
-            if resolved is not None and resolved is not param.annotation:
-                param = param.replace(annotation=resolved)
+            # Only swap in the resolved hint when the source annotation was a
+            # string (PEP 563). For live ``Annotated[...]`` objects we already
+            # have the real type, and ``get_type_hints`` on Python 3.10/3.11
+            # would silently wrap params with ``None`` defaults in
+            # ``Optional[...]``, hiding the inner ``Annotated`` from
+            # ``_unwrap_annotated`` and dropping wire-name aliases.
+            if isinstance(param.annotation, str):
+                resolved = resolved_hints.get(pname)
+                if resolved is not None:
+                    param = param.replace(annotation=resolved)
             collected.append((pname, param))
     return collected
 

--- a/litestar_mcp/schema_builder.py
+++ b/litestar_mcp/schema_builder.py
@@ -2,12 +2,11 @@
 
 import contextlib
 import inspect
+import logging
+import typing as _typing
 from collections import deque
 from types import UnionType
 from typing import TYPE_CHECKING, Annotated, Any, Union, get_args, get_origin
-
-if TYPE_CHECKING:
-    from litestar.handlers import BaseRouteHandler
 
 from litestar.constants import RESERVED_KWARGS
 from litestar.params import ParameterKwarg
@@ -20,6 +19,13 @@ from litestar_mcp.typing import (
     is_pydantic_model,
 )
 from litestar_mcp.utils import get_handler_function
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from litestar.handlers import BaseRouteHandler
+
+_logger = logging.getLogger(__name__)
 
 _EXECUTION_CONTEXT_PARAMS = {"resolved_user", "user_claims"}
 
@@ -46,41 +52,76 @@ def _unwrap_annotated(annotation: Any) -> "tuple[Any, list[ParameterKwarg]]":
 
 
 def _wire_name_for(python_name: str, param: inspect.Parameter) -> str:
-    """Return the externally visible wire name for ``param``."""
+    """Return the externally visible wire name for ``param``.
+
+    Only ``Parameter(query=...)`` aliases produce a distinct wire name. Header
+    and cookie sources are not yet routed by the MCP dispatcher, so a provider
+    that declares ``Parameter(header=...)`` will surface under its python name
+    in the inputSchema; this is logged at DEBUG so it's discoverable.
+    """
     _, metas = _unwrap_annotated(param.annotation)
     for meta in metas:
         if meta.query:
             return meta.query
+        if meta.header or meta.cookie:
+            _logger.debug(
+                "Provider param %r declares non-query source (header/cookie); wire name falls back to python name.",
+                python_name,
+            )
     return python_name
 
 
 def iter_dependency_input_parameters(
     handler: "BaseRouteHandler",
+    *,
+    path_param_names: "Iterable[str] | None" = None,
 ) -> "list[tuple[str, inspect.Parameter]]":
-    """Walk dependency providers transitively and yield their user-input params.
+    """Walk dependency providers and yield their user-input params.
 
     Litestar's HTTP routing inherits query/path/form params declared on a
     :class:`~litestar.di.Provide` factory up to the route, so the MCP tool
-    schema must mirror them. This walks ``handler.resolve_dependencies()``
-    plus each provider's own ``Provide`` graph, skipping:
+    schema must mirror them. This walks every ``Provide`` reachable from
+    ``handler.resolve_dependencies()`` -- which Litestar resolves across all
+    layered scopes (app/router/controller/handler) -- plus any sub-provider
+    whose parameter name also resolves to a known DI key. Names skipped:
 
     * names that are themselves DI keys (those are providers, not inputs);
     * :data:`litestar.constants.RESERVED_KWARGS` (framework injections like
       ``state`` / ``request`` / ``scope``);
-    * :data:`_EXECUTION_CONTEXT_PARAMS` (auth context keys).
+    * :data:`_EXECUTION_CONTEXT_PARAMS` (auth context keys);
+    * ``path_param_names`` when supplied (path-bound values aren't user input
+      from the MCP caller's perspective at the schema layer).
 
     Returns a list of ``(python_name, inspect.Parameter)`` in stable order.
     Duplicate python names across providers are deduplicated by first-seen.
+
+    Note:
+        Sub-providers registered at scopes the handler does not reference are
+        not walked: ``resolve_dependencies()`` already returns the full layered
+        DI graph visible to this handler. If your codebase relies on deeper
+        graphs, advertise the relevant params directly on the handler.
     """
     try:
         top_deps = dict(handler.resolve_dependencies())
-    except Exception:  # noqa: BLE001
+    except Exception as exc:  # noqa: BLE001
+        # Broken DI on a handler means the route itself can't serve requests,
+        # but schema-build runs at app startup -- propagating here would block
+        # the whole app from booting because of one bad route. Log loudly so
+        # operators can correlate "empty inputSchema" with the underlying DI
+        # failure rather than silently shrinking the schema.
+        handler_name = getattr(get_handler_function(handler), "__name__", "<handler>")
+        _logger.warning(
+            "Failed to resolve dependencies for handler %r; provider params will be omitted from MCP schema: %s",
+            handler_name,
+            exc,
+        )
         return []
     if not top_deps:
         return []
 
     dep_names: set[str] = set(top_deps)
-    framework_skip = RESERVED_KWARGS | _EXECUTION_CONTEXT_PARAMS
+    path_skip: set[str] = set(path_param_names) if path_param_names else set()
+    framework_skip = RESERVED_KWARGS | _EXECUTION_CONTEXT_PARAMS | path_skip
 
     # Cycle key is the provider *function* identity, not the Provide wrapper:
     # two Provides registered under different names with sync/cache flag
@@ -102,8 +143,22 @@ def iter_dependency_input_parameters(
         visited.add(provider_id)
         try:
             provider_sig = inspect.signature(provider_fn)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError) as exc:
+            _logger.debug(
+                "Skipping provider %r: signature introspection failed (%s).",
+                getattr(provider_fn, "__name__", repr(provider_fn)),
+                exc,
+            )
             continue
+
+        # Resolve stringified annotations (PEP 563 / ``from __future__ import
+        # annotations``) so downstream consumers -- the schema builder and
+        # ``routes._validate_tool_arguments`` -- see real types rather than
+        # ``'int'`` strings. ``inspect.signature`` does not eval forward refs.
+        try:
+            resolved_hints = _typing.get_type_hints(provider_fn, include_extras=True)
+        except Exception:  # noqa: BLE001
+            resolved_hints = {}
 
         for pname, param in provider_sig.parameters.items():
             if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
@@ -119,6 +174,9 @@ def iter_dependency_input_parameters(
             if pname in seen_names:
                 continue
             seen_names.add(pname)
+            resolved = resolved_hints.get(pname)
+            if resolved is not None and resolved is not param.annotation:
+                param = param.replace(annotation=resolved)
             collected.append((pname, param))
     return collected
 
@@ -428,6 +486,33 @@ def generate_schema_for_handler(handler: "BaseRouteHandler") -> "dict[str, Any]"
     return schema
 
 
+def _record_alias(
+    aliases: "dict[str, str]",
+    python_name: str,
+    wire_name: str,
+    handler_name: str,
+) -> None:
+    """Insert ``{wire_name: python_name}`` into ``aliases``; raise on real collision.
+
+    Same-python-name re-emissions (e.g. a path param echoed by a provider) are
+    no-ops, matching the dedupe semantics in :func:`generate_schema_for_handler`.
+    Different python names mapping to one wire name is a wire-contract bug --
+    raise rather than silently dropping the later entry.
+    """
+    if wire_name == python_name:
+        return
+    existing = aliases.get(wire_name)
+    if existing is None:
+        aliases[wire_name] = python_name
+        return
+    if existing == python_name:
+        return
+    msg = (
+        f"Wire-name collision in handler {handler_name!r}: {wire_name!r} maps to both {existing!r} and {python_name!r}"
+    )
+    raise ValueError(msg)
+
+
 def parameter_aliases(handler: "BaseRouteHandler") -> "dict[str, str]":
     """Return ``{wire_name: python_name}`` for handler params whose wire name differs.
 
@@ -435,6 +520,9 @@ def parameter_aliases(handler: "BaseRouteHandler") -> "dict[str, str]":
     are intentionally ignored — the executor only synthesizes query strings,
     so exposing those wire names would produce schemas the dispatcher cannot
     honor. Re-add them when header/cookie dispatch lands (out of scope for #52).
+
+    Raises ``ValueError`` on real wire-name collisions (the same alias mapping
+    to two different python names), mirroring :func:`generate_schema_for_handler`.
     """
     try:
         fn = get_handler_function(handler)
@@ -446,13 +534,10 @@ def parameter_aliases(handler: "BaseRouteHandler") -> "dict[str, str]":
     except (TypeError, ValueError):
         return {}
 
+    handler_name = getattr(fn, "__name__", "<handler>")
     aliases: dict[str, str] = {}
     for python_name, param in sig.parameters.items():
-        wire_name = _wire_name_for(python_name, param)
-        if wire_name != python_name:
-            aliases[wire_name] = python_name
+        _record_alias(aliases, python_name, _wire_name_for(python_name, param), handler_name)
     for python_name, param in iter_dependency_input_parameters(handler):
-        wire_name = _wire_name_for(python_name, param)
-        if wire_name != python_name and wire_name not in aliases:
-            aliases[wire_name] = python_name
+        _record_alias(aliases, python_name, _wire_name_for(python_name, param), handler_name)
     return aliases

--- a/litestar_mcp/schema_builder.py
+++ b/litestar_mcp/schema_builder.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Union, get_args, get_origin
 if TYPE_CHECKING:
     from litestar.handlers import BaseRouteHandler
 
+from litestar.constants import RESERVED_KWARGS
 from litestar.params import ParameterKwarg
 
 from litestar_mcp.typing import (
@@ -41,6 +42,80 @@ def _unwrap_annotated(annotation: Any) -> "tuple[Any, list[ParameterKwarg]]":
         args = get_args(annotation)
         return args[0], [m for m in args[1:] if isinstance(m, ParameterKwarg)]
     return annotation, []
+
+
+def _wire_name_for(python_name: str, param: inspect.Parameter) -> str:
+    """Return the externally visible wire name for ``param``."""
+    _, metas = _unwrap_annotated(param.annotation)
+    for meta in metas:
+        if meta.query:
+            return meta.query
+    return python_name
+
+
+def iter_dependency_input_parameters(
+    handler: "BaseRouteHandler",
+) -> "list[tuple[str, inspect.Parameter]]":
+    """Walk dependency providers transitively and yield their user-input params.
+
+    Litestar's HTTP routing inherits query/path/form params declared on a
+    :class:`~litestar.di.Provide` factory up to the route, so the MCP tool
+    schema must mirror them. This walks ``handler.resolve_dependencies()``
+    plus each provider's own ``Provide`` graph, skipping:
+
+    * names that are themselves DI keys (those are providers, not inputs);
+    * :data:`litestar.constants.RESERVED_KWARGS` (framework injections like
+      ``state`` / ``request`` / ``scope``);
+    * :data:`_EXECUTION_CONTEXT_PARAMS` (auth context keys).
+
+    Returns a list of ``(python_name, inspect.Parameter)`` in stable order.
+    Duplicate python names across providers are deduplicated by first-seen.
+    """
+    try:
+        top_deps = dict(handler.resolve_dependencies())
+    except Exception:  # noqa: BLE001
+        return []
+    if not top_deps:
+        return []
+
+    dep_names: set[str] = set(top_deps)
+    framework_skip = RESERVED_KWARGS | _EXECUTION_CONTEXT_PARAMS
+
+    visited: set[int] = set()
+    seen_names: set[str] = set()
+    collected: list[tuple[str, inspect.Parameter]] = []
+    stack: list[Any] = list(top_deps.values())
+
+    while stack:
+        provide = stack.pop(0)
+        provider_fn = getattr(provide, "dependency", None)
+        if provider_fn is None:
+            continue
+        provider_id = id(provider_fn)
+        if provider_id in visited:
+            continue
+        visited.add(provider_id)
+        try:
+            provider_sig = inspect.signature(provider_fn)
+        except (TypeError, ValueError):
+            continue
+
+        for pname, param in provider_sig.parameters.items():
+            if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+                continue
+            if pname in framework_skip:
+                continue
+            if pname in dep_names:
+                # Transitive provider — walk it but do not emit as user input.
+                nested = top_deps.get(pname)
+                if nested is not None:
+                    stack.append(nested)
+                continue
+            if pname in seen_names:
+                continue
+            seen_names.add(pname)
+            collected.append((pname, param))
+    return collected
 
 
 _META_FIELD_MAP: "tuple[tuple[str, str], ...]" = (
@@ -291,11 +366,9 @@ def generate_schema_for_handler(handler: "BaseRouteHandler") -> "dict[str, Any]"
     properties: dict[str, Any] = {}
     required: list[str] = []
     wire_to_python: dict[str, str] = {}
+    handler_name = getattr(fn, "__name__", "<handler>")
 
-    for python_name, param in sig.parameters.items():
-        if python_name in di_params or python_name in _EXECUTION_CONTEXT_PARAMS:
-            continue
-
+    def _emit(python_name: str, param: inspect.Parameter) -> None:
         _, metas = _unwrap_annotated(param.annotation)
         wire_name = python_name
         for meta in metas:
@@ -303,9 +376,10 @@ def generate_schema_for_handler(handler: "BaseRouteHandler") -> "dict[str, Any]"
                 wire_name = meta.query
                 break
 
-        if wire_name in wire_to_python and wire_to_python[wire_name] != python_name:
+        if wire_name in wire_to_python:
+            if wire_to_python[wire_name] == python_name:
+                return
             existing = wire_to_python[wire_name]
-            handler_name = getattr(fn, "__name__", "<handler>")
             msg = (
                 f"Wire-name collision in handler {handler_name!r}: "
                 f"{wire_name!r} maps to both {existing!r} and {python_name!r}"
@@ -324,6 +398,14 @@ def generate_schema_for_handler(handler: "BaseRouteHandler") -> "dict[str, Any]"
 
         if param.default is inspect.Parameter.empty:
             required.append(wire_name)
+
+    for python_name, param in sig.parameters.items():
+        if python_name in di_params or python_name in _EXECUTION_CONTEXT_PARAMS:
+            continue
+        _emit(python_name, param)
+
+    for python_name, param in iter_dependency_input_parameters(handler):
+        _emit(python_name, param)
 
     schema: dict[str, Any] = {
         "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -369,6 +451,13 @@ def parameter_aliases(handler: "BaseRouteHandler") -> "dict[str, str]":
         for meta in metas:
             wire_name = meta.query
             if wire_name and wire_name != python_name:
+                aliases[wire_name] = python_name
+                break
+    for python_name, param in iter_dependency_input_parameters(handler):
+        _, metas = _unwrap_annotated(param.annotation)
+        for meta in metas:
+            wire_name = meta.query
+            if wire_name and wire_name != python_name and wire_name not in aliases:
                 aliases[wire_name] = python_name
                 break
     return aliases

--- a/litestar_mcp/schema_builder.py
+++ b/litestar_mcp/schema_builder.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import inspect
+from collections import deque
 from types import UnionType
 from typing import TYPE_CHECKING, Annotated, Any, Union, get_args, get_origin
 
@@ -81,13 +82,17 @@ def iter_dependency_input_parameters(
     dep_names: set[str] = set(top_deps)
     framework_skip = RESERVED_KWARGS | _EXECUTION_CONTEXT_PARAMS
 
+    # Cycle key is the provider *function* identity, not the Provide wrapper:
+    # two Provides registered under different names with sync/cache flag
+    # differences but the same underlying callable have identical signatures,
+    # so walking either yields the same params.
     visited: set[int] = set()
     seen_names: set[str] = set()
     collected: list[tuple[str, inspect.Parameter]] = []
-    stack: list[Any] = list(top_deps.values())
+    queue: deque[Any] = deque(top_deps.values())
 
-    while stack:
-        provide = stack.pop(0)
+    while queue:
+        provide = queue.popleft()
         provider_fn = getattr(provide, "dependency", None)
         if provider_fn is None:
             continue
@@ -109,7 +114,7 @@ def iter_dependency_input_parameters(
                 # Transitive provider — walk it but do not emit as user input.
                 nested = top_deps.get(pname)
                 if nested is not None:
-                    stack.append(nested)
+                    queue.append(nested)
                 continue
             if pname in seen_names:
                 continue
@@ -369,12 +374,8 @@ def generate_schema_for_handler(handler: "BaseRouteHandler") -> "dict[str, Any]"
     handler_name = getattr(fn, "__name__", "<handler>")
 
     def _emit(python_name: str, param: inspect.Parameter) -> None:
+        wire_name = _wire_name_for(python_name, param)
         _, metas = _unwrap_annotated(param.annotation)
-        wire_name = python_name
-        for meta in metas:
-            if meta.query:
-                wire_name = meta.query
-                break
 
         if wire_name in wire_to_python:
             if wire_to_python[wire_name] == python_name:
@@ -447,17 +448,11 @@ def parameter_aliases(handler: "BaseRouteHandler") -> "dict[str, str]":
 
     aliases: dict[str, str] = {}
     for python_name, param in sig.parameters.items():
-        _, metas = _unwrap_annotated(param.annotation)
-        for meta in metas:
-            wire_name = meta.query
-            if wire_name and wire_name != python_name:
-                aliases[wire_name] = python_name
-                break
+        wire_name = _wire_name_for(python_name, param)
+        if wire_name != python_name:
+            aliases[wire_name] = python_name
     for python_name, param in iter_dependency_input_parameters(handler):
-        _, metas = _unwrap_annotated(param.annotation)
-        for meta in metas:
-            wire_name = meta.query
-            if wire_name and wire_name != python_name and wire_name not in aliases:
-                aliases[wire_name] = python_name
-                break
+        wire_name = _wire_name_for(python_name, param)
+        if wire_name != python_name and wire_name not in aliases:
+            aliases[wire_name] = python_name
     return aliases

--- a/litestar_mcp/utils/handler_signature.py
+++ b/litestar_mcp/utils/handler_signature.py
@@ -148,8 +148,8 @@ def get_advertised_handler_parameters(
         advertised_names.add(name)
 
     path_param_names = _path_parameter_names(path_parameters)
-    for name, param in iter_dependency_input_parameters(handler):
-        if name in advertised_names or name in path_param_names:
+    for name, param in iter_dependency_input_parameters(handler, path_param_names=path_param_names):
+        if name in advertised_names:
             continue
         wire_name = python_to_wire.get(name, name)
         description = doc_descriptions.get(name) or doc_descriptions.get(wire_name)

--- a/litestar_mcp/utils/handler_signature.py
+++ b/litestar_mcp/utils/handler_signature.py
@@ -1,6 +1,7 @@
 """Helpers for Litestar handler argument advertisement."""
 
 import contextlib
+import inspect
 import re
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
@@ -9,7 +10,7 @@ from typing import Any
 from litestar.constants import RESERVED_KWARGS
 from litestar.handlers import BaseRouteHandler
 
-from litestar_mcp.schema_builder import parameter_aliases
+from litestar_mcp.schema_builder import iter_dependency_input_parameters, parameter_aliases
 from litestar_mcp.utils import get_handler_function
 
 
@@ -129,6 +130,7 @@ def get_advertised_handler_parameters(
     doc_descriptions = _parse_docstring_args(getattr(fn, "__doc__", None))
 
     advertised: list[AdvertisedHandlerParameter] = []
+    advertised_names: set[str] = set()
     for name, definition in parsed_parameters.items():
         if name == "self" or name in skipped_names:
             continue
@@ -143,6 +145,24 @@ def get_advertised_handler_parameters(
                 description=description or None,
             )
         )
+        advertised_names.add(name)
+
+    path_param_names = _path_parameter_names(path_parameters)
+    for name, param in iter_dependency_input_parameters(handler):
+        if name in advertised_names or name in path_param_names:
+            continue
+        wire_name = python_to_wire.get(name, name)
+        description = doc_descriptions.get(name) or doc_descriptions.get(wire_name)
+        advertised.append(
+            AdvertisedHandlerParameter(
+                python_name=name,
+                wire_name=wire_name,
+                annotation=param.annotation,
+                required=param.default is inspect.Parameter.empty,
+                description=description or None,
+            )
+        )
+        advertised_names.add(name)
     return advertised
 
 

--- a/tests/unit/test_input_validation.py
+++ b/tests/unit/test_input_validation.py
@@ -194,3 +194,65 @@ class TestInputValidation:
             assert "result" in result
             assert result["result"]["isError"] is False
             assert json.loads(result["result"]["content"][0]["text"]) == {"hello": "world"}
+
+    def test_provider_only_param_does_not_crash_validator(self) -> None:
+        """Provider-declared params don't appear in ``parsed_fn_signature``.
+
+        Before the fix, ``declared_by_name[name]`` raised ``KeyError`` for any
+        provider param that reached ``_validate_tool_arguments``; with the
+        fallback to ``advertised_by_name[name].annotation`` the call now
+        succeeds. Direct-call assertion against ``_validate_tool_arguments``
+        bypasses ``from __future__ import annotations`` stringification of the
+        provider's annotations (msgspec can't validate ``'int'`` strings) so
+        we can also assert the bad-payload error envelope.
+        """
+        from litestar.params import Dependency
+
+        from litestar_mcp.routes import _validate_tool_arguments
+
+        async def provide_pagination(limit: int = 20, offset: int = 0) -> dict[str, int]:
+            return {"limit": limit, "offset": offset}
+
+        # Strip the ``__future__ annotations`` stringification so msgspec sees
+        # real types when the validator falls back to provider annotations.
+        provide_pagination.__annotations__ = {
+            "limit": int,
+            "offset": int,
+            "return": dict[str, int],
+        }
+
+        @get(
+            "/pp",
+            opt={"mcp_tool": "pp_tool"},
+            dependencies={"pagination": Provide(provide_pagination)},
+            sync_to_thread=False,
+        )
+        def pp_tool(
+            pagination: Annotated[dict[str, int], Dependency(skip_validation=True)],
+        ) -> dict[str, int]:
+            return pagination
+
+        app = Litestar(route_handlers=[pp_tool], plugins=[LitestarMCP(MCPConfig())])
+
+        handler = next(
+            rh
+            for route in app.routes
+            for rh in getattr(route, "route_handlers", [])
+            if getattr(rh, "fn", None) is pp_tool.fn  # type: ignore[union-attr]
+        )
+
+        # Happy path: previously raised KeyError on ``declared_by_name[name]``.
+        assert _validate_tool_arguments(handler, {"limit": 7, "offset": 3}) == []
+
+        # Type coercion uses the provider's annotation as the fallback.
+        errs = _validate_tool_arguments(handler, {"limit": "not-an-int"})
+        paths = {e["path"] for e in errs}
+        assert "/arguments/limit" in paths, errs
+
+        # End-to-end smoke: the JSON-RPC dispatcher accepts the provider params
+        # without 4xx-ing at the HTTP layer.
+        with TestClient(app=app) as client:
+            ok = _call(client, "pp_tool", {"limit": 7, "offset": 3})
+            assert "result" in ok
+            assert ok["result"]["isError"] is False
+            assert json.loads(ok["result"]["content"][0]["text"]) == {"limit": 7, "offset": 3}

--- a/tests/unit/test_input_validation.py
+++ b/tests/unit/test_input_validation.py
@@ -238,7 +238,7 @@ class TestInputValidation:
             rh
             for route in app.routes
             for rh in getattr(route, "route_handlers", [])
-            if getattr(rh, "fn", None) is pp_tool.fn  # type: ignore[union-attr]
+            if getattr(rh, "fn", None) is pp_tool.fn
         )
 
         # Happy path: previously raised KeyError on ``declared_by_name[name]``.

--- a/tests/unit/test_input_validation.py
+++ b/tests/unit/test_input_validation.py
@@ -199,12 +199,11 @@ class TestInputValidation:
         """Provider-declared params don't appear in ``parsed_fn_signature``.
 
         Before the fix, ``declared_by_name[name]`` raised ``KeyError`` for any
-        provider param that reached ``_validate_tool_arguments``; with the
-        fallback to ``advertised_by_name[name].annotation`` the call now
-        succeeds. Direct-call assertion against ``_validate_tool_arguments``
-        bypasses ``from __future__ import annotations`` stringification of the
-        provider's annotations (msgspec can't validate ``'int'`` strings) so
-        we can also assert the bad-payload error envelope.
+        provider param that reached ``_validate_tool_arguments``. The fallback
+        resolves the provider's annotations via ``typing.get_type_hints`` at
+        walk time, so PEP 563 stringified annotations (this module uses
+        ``from __future__ import annotations``) resolve to real types --
+        ``msgspec.convert`` would otherwise see ``'int'`` strings and bail.
         """
         from litestar.params import Dependency
 
@@ -212,14 +211,6 @@ class TestInputValidation:
 
         async def provide_pagination(limit: int = 20, offset: int = 0) -> dict[str, int]:
             return {"limit": limit, "offset": offset}
-
-        # Strip the ``__future__ annotations`` stringification so msgspec sees
-        # real types when the validator falls back to provider annotations.
-        provide_pagination.__annotations__ = {
-            "limit": int,
-            "offset": int,
-            "return": dict[str, int],
-        }
 
         @get(
             "/pp",

--- a/tests/unit/test_schema_builder.py
+++ b/tests/unit/test_schema_builder.py
@@ -877,3 +877,119 @@ class TestGenerateSchemaWireNamesAndDocClobber:
         assert set(schema["properties"]) == {"is_paid", "name"}
         assert "anyOf" in schema["properties"]["is_paid"]
         assert "anyOf" in schema["properties"]["name"]
+
+
+class TestDependencyProviderParameters:
+    """Provider params (e.g. limit/offset on a Provide(...) factory) must surface."""
+
+    @staticmethod
+    def _build_handler(handler_func: Any, dependencies: dict[str, Any]) -> Any:
+        from litestar import Litestar, get
+
+        from tests.unit.conftest import get_handler_from_app
+
+        decorated = get("/x", sync_to_thread=False)(handler_func)
+        app = Litestar(route_handlers=[decorated], dependencies=dependencies)
+        return get_handler_from_app(app, "/x")
+
+    def test_direct_provider_params_appear_in_schema(self) -> None:
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        async def provide_pagination(limit: int = 20, offset: int = 0) -> dict[str, int]:
+            return {"limit": limit, "offset": offset}
+
+        async def handler(
+            pagination: Annotated[dict[str, int], Dependency(skip_validation=True)],
+        ) -> dict[str, int]:
+            return pagination
+
+        h = self._build_handler(handler, {"pagination": Provide(provide_pagination)})
+        schema = generate_schema_for_handler(h)
+        assert set(schema["properties"]) == {"limit", "offset"}
+        assert schema["properties"]["limit"] == {"type": "integer"}
+        assert schema["properties"]["offset"] == {"type": "integer"}
+        assert "required" not in schema  # both have defaults
+
+    def test_transitive_provider_params_appear_in_schema(self) -> None:
+        from litestar.di import Provide
+        from litestar.params import Dependency, Parameter
+
+        async def provide_base(
+            filter_q: Annotated[str | None, Parameter(query="q")] = None,
+        ) -> dict[str, Any]:
+            return {"q": filter_q}
+
+        async def provide_pagination(
+            base: dict[str, Any], limit: int = 20, offset: int = 0
+        ) -> dict[str, Any]:
+            return {"limit": limit, "offset": offset, **base}
+
+        async def handler(
+            pagination: Annotated[dict[str, Any], Dependency(skip_validation=True)],
+        ) -> dict[str, Any]:
+            return pagination
+
+        h = self._build_handler(
+            handler,
+            {"pagination": Provide(provide_pagination), "base": Provide(provide_base)},
+        )
+        schema = generate_schema_for_handler(h)
+        assert set(schema["properties"]) == {"limit", "offset", "q"}
+
+    def test_provider_framework_kwargs_are_skipped(self) -> None:
+        """Providers that take state/request etc. must not leak those as user input."""
+        from litestar import Request
+        from litestar.datastructures import State
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        async def provide_context(state: State, request: Request, limit: int = 10) -> dict[str, Any]:
+            return {"limit": limit}
+
+        async def handler(
+            ctx: Annotated[dict[str, Any], Dependency(skip_validation=True)],
+        ) -> dict[str, Any]:
+            return ctx
+
+        h = self._build_handler(handler, {"ctx": Provide(provide_context)})
+        schema = generate_schema_for_handler(h)
+        assert set(schema["properties"]) == {"limit"}
+
+    def test_provider_with_no_params_does_not_break(self) -> None:
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        async def provide_thing() -> dict[str, Any]:
+            return {}
+
+        async def handler(
+            thing: Annotated[dict[str, Any], Dependency(skip_validation=True)],
+        ) -> dict[str, Any]:
+            return thing
+
+        h = self._build_handler(handler, {"thing": Provide(provide_thing)})
+        schema = generate_schema_for_handler(h)
+        assert schema["properties"] == {}
+
+    def test_provider_param_wire_alias_round_trips(self) -> None:
+        from litestar.di import Provide
+        from litestar.params import Dependency, Parameter
+
+        from litestar_mcp.schema_builder import parameter_aliases
+
+        async def provide_filter(
+            user_id: Annotated[str | None, Parameter(query="userId")] = None,
+        ) -> dict[str, Any]:
+            return {"user_id": user_id}
+
+        async def handler(
+            flt: Annotated[dict[str, Any], Dependency(skip_validation=True)],
+        ) -> dict[str, Any]:
+            return flt
+
+        h = self._build_handler(handler, {"flt": Provide(provide_filter)})
+        schema = generate_schema_for_handler(h)
+        assert "userId" in schema["properties"]
+        assert "user_id" not in schema["properties"]
+        assert parameter_aliases(h) == {"userId": "user_id"}

--- a/tests/unit/test_schema_builder.py
+++ b/tests/unit/test_schema_builder.py
@@ -1020,3 +1020,133 @@ class TestDependencyProviderParameters:
         assert "userId" in schema["properties"]
         assert "user_id" not in schema["properties"]
         assert parameter_aliases(h) == {"userId": "user_id"}
+
+    def test_shared_callable_across_providers_is_walked_once(self) -> None:
+        """Cycle protection keys on the provider function, not the Provide wrapper.
+
+        Two ``Provide`` entries that wrap the same callable have identical
+        signatures; the BFS visited set keyed on ``id(provider_fn)`` should
+        keep the walk O(unique providers) and emit each param once.
+        """
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        async def shared(limit: int = 20) -> int:
+            return limit
+
+        async def handler(
+            a: Annotated[int, Dependency(skip_validation=True)],
+            b: Annotated[int, Dependency(skip_validation=True)],
+        ) -> dict[str, int]:
+            return {"a": a, "b": b}
+
+        # Litestar rejects two equal ``Provide`` instances under different
+        # keys; differentiate via ``use_cache`` so the wrappers are unequal
+        # while the underlying callable is shared.
+        h = self._build_handler(
+            handler,
+            {"a": Provide(shared), "b": Provide(shared, use_cache=True)},
+        )
+        schema = generate_schema_for_handler(h)
+        assert set(schema["properties"]) == {"limit"}
+
+    def test_sync_provider_params_appear_in_schema(self) -> None:
+        """The BFS uses ``inspect.signature`` which handles sync providers identically."""
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        def provide_pagination(limit: int = 20, offset: int = 0) -> dict[str, int]:
+            return {"limit": limit, "offset": offset}
+
+        async def handler(
+            pagination: Annotated[dict[str, int], Dependency(skip_validation=True)],
+        ) -> dict[str, int]:
+            return pagination
+
+        h = self._build_handler(handler, {"pagination": Provide(provide_pagination, sync_to_thread=False)})
+        schema = generate_schema_for_handler(h)
+        assert set(schema["properties"]) == {"limit", "offset"}
+
+    def test_provider_return_type_does_not_leak_into_schema(self) -> None:
+        """Only the provider's *inputs* matter; the model it returns must not surface its own fields."""
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        @dataclass
+        class FilterModel:
+            limit: int
+            offset: int
+
+        async def provide_filter(q: str | None = None) -> FilterModel:
+            return FilterModel(limit=20, offset=0)
+
+        async def handler(
+            flt: Annotated[FilterModel, Dependency(skip_validation=True)],
+        ) -> dict[str, Any]:
+            return {"q": flt}
+
+        h = self._build_handler(handler, {"flt": Provide(provide_filter)})
+        schema = generate_schema_for_handler(h)
+        assert set(schema["properties"]) == {"q"}
+
+    def test_handler_provider_query_collision_raises(self) -> None:
+        """Two distinct python names aliased to the same wire name -> ValueError."""
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        async def provide_filter(
+            other_id: Annotated[str | None, Parameter(query="id")] = None,
+        ) -> dict[str, Any]:
+            return {"id": other_id}
+
+        async def handler(
+            user_id: Annotated[str | None, Parameter(query="id")] = None,
+            flt: Annotated[dict[str, Any] | None, Dependency(skip_validation=True)] = None,
+        ) -> dict[str, Any]:
+            return {"user_id": user_id, **(flt or {})}
+
+        h = self._build_handler(handler, {"flt": Provide(provide_filter)})
+        with pytest.raises(ValueError, match="Wire-name collision"):
+            generate_schema_for_handler(h)
+
+    def test_handler_provider_same_python_name_dedupes(self) -> None:
+        """Same python name appearing on both handler and provider is a no-op dedupe, not a collision."""
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        async def provide_audit(limit: int = 20) -> dict[str, int]:
+            return {"limit": limit}
+
+        async def handler(
+            limit: int = 20,
+            audit: Annotated[dict[str, int] | None, Dependency(skip_validation=True)] = None,
+        ) -> dict[str, int]:
+            return {"limit": limit, **(audit or {})}
+
+        h = self._build_handler(handler, {"audit": Provide(provide_audit)})
+        schema = generate_schema_for_handler(h)
+        assert set(schema["properties"]) == {"limit"}
+
+    def test_provider_header_param_does_not_become_query_alias(self) -> None:
+        """Header-sourced provider params surface under their python name, not as wire aliases."""
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        async def provide_ctx(
+            tenant: Annotated[str | None, Parameter(header="X-Tenant")] = None,
+        ) -> dict[str, Any]:
+            return {"tenant": tenant}
+
+        async def handler(
+            ctx: Annotated[dict[str, Any], Dependency(skip_validation=True)],
+        ) -> dict[str, Any]:
+            return ctx
+
+        h = self._build_handler(handler, {"ctx": Provide(provide_ctx)})
+        schema = generate_schema_for_handler(h)
+        # Header param falls back to python name -- not aliased to the header name.
+        from litestar_mcp.schema_builder import parameter_aliases as _pa
+
+        assert "tenant" in schema["properties"]
+        assert "X-Tenant" not in schema["properties"]
+        assert _pa(h) == {}

--- a/tests/unit/test_schema_builder.py
+++ b/tests/unit/test_schema_builder.py
@@ -972,6 +972,36 @@ class TestDependencyProviderParameters:
         schema = generate_schema_for_handler(h)
         assert schema["properties"] == {}
 
+    def test_path_param_collision_dedupes_to_single_emission(self) -> None:
+        """If a provider declares the same name as a path param, the handler's
+        own sig walk emits it first; the provider walk must be a no-op for
+        that name rather than raising a wire-name collision."""
+        from litestar import Litestar, get
+        from litestar.di import Provide
+        from litestar.params import Dependency
+
+        from tests.unit.conftest import get_handler_from_app
+
+        async def provide_audit(user_id: str) -> dict[str, str]:
+            return {"user_id": user_id}
+
+        async def handler(
+            user_id: str,
+            audit: Annotated[dict[str, str], Dependency(skip_validation=True)],
+        ) -> dict[str, str]:
+            return {"user_id": user_id, **audit}
+
+        decorated = get("/items/{user_id:str}", sync_to_thread=False)(handler)
+        app = Litestar(route_handlers=[decorated], dependencies={"audit": Provide(provide_audit)})
+        h = next(
+            rh
+            for route in app.routes
+            for rh in getattr(route, "route_handlers", [getattr(route, "route_handler", None)])
+            if rh is not None and "user_id" in getattr(route, "path", "")
+        )
+        schema = generate_schema_for_handler(h)
+        assert set(schema["properties"]) == {"user_id"}
+
     def test_provider_param_wire_alias_round_trips(self) -> None:
         from litestar.di import Provide
         from litestar.params import Dependency, Parameter

--- a/tests/unit/test_schema_builder.py
+++ b/tests/unit/test_schema_builder.py
@@ -920,9 +920,7 @@ class TestDependencyProviderParameters:
         ) -> dict[str, Any]:
             return {"q": filter_q}
 
-        async def provide_pagination(
-            base: dict[str, Any], limit: int = 20, offset: int = 0
-        ) -> dict[str, Any]:
+        async def provide_pagination(base: dict[str, Any], limit: int = 20, offset: int = 0) -> dict[str, Any]:
             return {"limit": limit, "offset": offset, **base}
 
         async def handler(
@@ -975,12 +973,11 @@ class TestDependencyProviderParameters:
     def test_path_param_collision_dedupes_to_single_emission(self) -> None:
         """If a provider declares the same name as a path param, the handler's
         own sig walk emits it first; the provider walk must be a no-op for
-        that name rather than raising a wire-name collision."""
+        that name rather than raising a wire-name collision.
+        """
         from litestar import Litestar, get
         from litestar.di import Provide
         from litestar.params import Dependency
-
-        from tests.unit.conftest import get_handler_from_app
 
         async def provide_audit(user_id: str) -> dict[str, str]:
             return {"user_id": user_id}

--- a/tests/unit/test_schema_builder.py
+++ b/tests/unit/test_schema_builder.py
@@ -942,7 +942,7 @@ class TestDependencyProviderParameters:
         from litestar.di import Provide
         from litestar.params import Dependency
 
-        async def provide_context(state: State, request: Request, limit: int = 10) -> dict[str, Any]:
+        async def provide_context(state: State, request: Request[Any, Any, Any], limit: int = 10) -> dict[str, Any]:
             return {"limit": limit}
 
         async def handler(


### PR DESCRIPTION
## Summary

Fixes #64. Query parameters declared on `Provide(...)` factories were missing from the MCP tool `inputSchema`, so MCP clients couldn't discover or use them — pagination silently capped at the default page size for every consumer of `advanced-alchemy`'s `service_dependencies` pattern.

- New `iter_dependency_input_parameters(handler)` walks `handler.resolve_dependencies()` transitively (BFS with `id()`-keyed cycle detection), skipping nested DI keys, `litestar.constants.RESERVED_KWARGS` (`state`, `request`, `scope`, …), and execution-context names (`resolved_user`, `user_claims`). Plugin-internal Provides (`config`, `registry`, `task_store`, `session_manager`) are zero-arg so they contribute nothing.
- Threaded through six touchpoints that previously walked only `inspect.signature(handler_fn)`:
  - `schema_builder.generate_schema_for_handler` — emits provider params with wire-name alias support.
  - `schema_builder.parameter_aliases` — surfaces `Parameter(query=...)` aliases from providers.
  - `executor._split_tool_args` — extends `scalar_sig_names` so MCP-supplied keys reach the synthesized query string.
  - `routes._validate_tool_arguments` — falls back to the advertised annotation when a provider-only param isn't on `parsed_fn_signature`.
  - `utils.handler_signature.get_advertised_handler_parameters` — surfaces provider params for prompt advertising.
  - `cli.py` — generates CLI options for provider params.

## Test plan

- [x] 5 new unit tests in `TestDependencyProviderParameters` covering direct, transitive, framework-kwarg skip, no-param provider, and wire-alias round-trip.
- [x] `uv run pytest tests/unit/` — 616 passed, 1 skipped.
- [x] `uv run pytest tests/integration/` — 98 passed.
- [x] Issue repro: `tools/list` now returns `{limit, offset}` on `via_provider_list`; `tools/call` with `{"limit":7,"offset":3}` reaches the provider and returns `{"limit":7,"offset":3}`.

Closes #64.