### PR TITLE
docs(reference): align API reference with merged stdio/callback/auth features

### DIFF
--- a/docs/reference/auth.rst
+++ b/docs/reference/auth.rst
@@ -1,0 +1,42 @@
+========
+Auth API
+========
+
+This module contains the built-in authentication middleware, the OIDC
+token-validation engine, and the injectable JWKS cache. The configuration
+dataclasses :class:`~litestar_mcp.auth.MCPAuthConfig` and
+:class:`~litestar_mcp.auth.OIDCProviderConfig` are documented under
+:doc:`types`.
+
+.. currentmodule:: litestar_mcp.auth
+
+MCPAuthBackend
+--------------
+
+.. autoclass:: MCPAuthBackend
+   :members:
+   :show-inheritance:
+
+create_oidc_validator
+---------------------
+
+.. autofunction:: create_oidc_validator
+
+TokenValidator
+--------------
+
+.. autodata:: TokenValidator
+
+JWKSCache
+---------
+
+.. autoclass:: JWKSCache
+   :members:
+   :show-inheritance:
+
+DefaultJWKSCache
+----------------
+
+.. autoclass:: DefaultJWKSCache
+   :members:
+   :show-inheritance:

--- a/docs/reference/config.rst
+++ b/docs/reference/config.rst
@@ -25,3 +25,23 @@ override the dataclass to remap a project to non-default opt keys.
 .. autoclass:: MCPOptKeys
    :members:
    :show-inheritance:
+
+BeforeToolCallHook
+------------------
+
+Structural :class:`~typing.Protocol` for the ``MCPConfig.before_tool_call``
+observability callback.
+
+.. autoclass:: BeforeToolCallHook
+   :members:
+   :show-inheritance:
+
+AfterToolCallHook
+-----------------
+
+Structural :class:`~typing.Protocol` for the ``MCPConfig.after_tool_call``
+observability callback.
+
+.. autoclass:: AfterToolCallHook
+   :members:
+   :show-inheritance:

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -9,5 +9,6 @@ API Reference
     plugin
     handlers
     types
+    auth
 
 This section provides detailed API documentation for all public interfaces.

--- a/docs/reference/plugin.rst
+++ b/docs/reference/plugin.rst
@@ -20,6 +20,21 @@ LitestarMCP
    decorated with :func:`~litestar_mcp.mcp_prompt` can be passed via the
    ``prompts`` constructor argument.
 
+.. currentmodule:: litestar_mcp.app
+
+MCP
+---
+
+.. autoclass:: MCP
+   :members:
+   :show-inheritance:
+
+   The standalone application wrapper. Builds a Litestar app pre-configured
+   with :class:`~litestar_mcp.LitestarMCP`, exposes ``@tool`` / ``@resource``
+   / ``@prompt`` decorators, and can serve over Streamable HTTP or stdio via
+   :meth:`MCP.run`. Pass a :class:`~litestar_mcp.MCPStdioContext` to
+   ``run(transport="stdio", stdio_context=...)`` to seed the caller identity.
+
 .. currentmodule:: litestar_mcp.registry
 
 Registry

--- a/docs/reference/types.rst
+++ b/docs/reference/types.rst
@@ -20,6 +20,20 @@ MCPTaskConfig
    :members:
    :show-inheritance:
 
+.. currentmodule:: litestar_mcp.app
+
+MCPStdioContext
+---------------
+
+Runtime identity for standalone stdio transports. Its fields seed the
+synthesized dispatch scope so handlers, guards, and task execution read the
+usual ``request.user`` / ``request.scope["auth"]`` / session / state. See
+:doc:`/usage/standalone_app` for the stdio walkthrough.
+
+.. autoclass:: MCPStdioContext
+   :members:
+   :show-inheritance:
+
 .. currentmodule:: litestar_mcp.registry
 
 PromptRegistration


### PR DESCRIPTION
## Summary

Audited the docs against the current public API (`litestar_mcp.__all__`) and recently merged PRs (#76 stdio identity, #69 tool-call callbacks). Several public symbols had **no reference-page autodoc**; the entire `litestar_mcp.auth` module had no reference page at all. This closes those gaps.

## Changes (reference pages only)

- **New `docs/reference/auth.rst`** (added to the reference toctree) — autodoc for `MCPAuthBackend`, `create_oidc_validator`, `TokenValidator`, `JWKSCache`, `DefaultJWKSCache`. (`MCPAuthConfig` / `OIDCProviderConfig` remain under `types.rst`; cross-linked to avoid duplicate-object warnings.)
- **`config.rst`** — `BeforeToolCallHook` / `AfterToolCallHook` protocols (from #69). The callback *behaviour* was already documented in `usage/configuration.rst`; only the exported Protocol types were missing.
- **`types.rst`** — `MCPStdioContext` (from #76), which surfaces its previously-undocumented `client_id` field via autodoc.
- **`plugin.rst`** — the standalone `MCP` application class.

## Verification

`make docs` (sphinx `-W --keep-going`) builds clean with no new warnings.

## Notes

This is a docs-only alignment pass, independent of the auth-header feature in #77. No code changes.