### PR TITLE
fix: hide MCP discovery routes from OpenAPI by default

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,20 @@ notes, and important protocol fixes.
 Recent Updates
 ==============
 
+.. changelog:: 0.11.1
+
+    .. change:: hide MCP plugin discovery routes from OpenAPI by default
+        :type: bugfix
+
+        ``MCPConfig.include_in_schema=False`` now hides the plugin-owned
+        ``/.well-known/oauth-protected-resource``,
+        ``/.well-known/agent-card.json``, and
+        ``/.well-known/mcp-server.json`` routes from generated OpenAPI
+        schemas, matching the existing default behavior for the ``/mcp``
+        transport route. Marked application routes remain visible in OpenAPI
+        unless the application hides them separately, and
+        ``include_in_schema=True`` opts all MCP plugin routes back in.
+
 .. changelog:: 0.11.0
 
     .. change:: support binary resources and explicit tool content blocks

--- a/litestar_mcp/plugin.py
+++ b/litestar_mcp/plugin.py
@@ -175,11 +175,21 @@ class LitestarMCP(InitPluginProtocol, CLIPlugin):
         app_config.on_startup.append(self.on_startup)
         app_config.on_shutdown.append(self.on_shutdown)
 
-        @litestar_get("/.well-known/oauth-protected-resource", sync_to_thread=False, opt={"exclude_from_auth": True})
+        @litestar_get(
+            "/.well-known/oauth-protected-resource",
+            sync_to_thread=False,
+            include_in_schema=self._config.include_in_schema,
+            opt={"exclude_from_auth": True},
+        )
         def oauth_protected_resource(request: "Request[Any, Any, Any]") -> "dict[str, Any]":
             return build_oauth_protected_resource(self._config.auth, request.app)
 
-        @litestar_get("/.well-known/agent-card.json", sync_to_thread=False, opt={"exclude_from_auth": True})
+        @litestar_get(
+            "/.well-known/agent-card.json",
+            sync_to_thread=False,
+            include_in_schema=self._config.include_in_schema,
+            opt={"exclude_from_auth": True},
+        )
         def agent_card(request: "Request[Any, Any, Any]") -> "dict[str, Any]":
             return build_agent_card(
                 base_url=str(request.base_url),
@@ -188,7 +198,12 @@ class LitestarMCP(InitPluginProtocol, CLIPlugin):
                 discovered_tools=self._registry.tools,
             )
 
-        @litestar_get("/.well-known/mcp-server.json", sync_to_thread=False, opt={"exclude_from_auth": True})
+        @litestar_get(
+            "/.well-known/mcp-server.json",
+            sync_to_thread=False,
+            include_in_schema=self._config.include_in_schema,
+            opt={"exclude_from_auth": True},
+        )
         def mcp_server_manifest(request: "Request[Any, Any, Any]") -> "dict[str, Any]":
             return build_mcp_server_manifest(
                 base_url=str(request.base_url),

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -4,6 +4,7 @@ import json
 from typing import Any
 
 from litestar import Litestar, get, post
+from litestar.openapi.config import OpenAPIConfig
 from litestar.testing import TestClient
 
 from litestar_mcp import LitestarMCP
@@ -50,6 +51,11 @@ def _rpc(
         if sid:
             headers["Mcp-Session-Id"] = sid
     return client.post(base, json=body, headers=headers).json()  # type: ignore[no-any-return]
+
+
+def _openapi_paths(app: "Litestar") -> "set[str]":
+    with TestClient(app=app) as client:
+        return set(client.get("/schema/openapi.json").json()["paths"])
 
 
 class TestLitestarMCP:
@@ -124,6 +130,44 @@ class TestLitestarMCP:
         contents = result["result"]["contents"]
         assert contents[0]["uri"] == "litestar://openapi"
 
+    def test_default_openapi_schema_hides_plugin_routes_only(self) -> "None":
+        @get("/users", mcp_tool="list_users")
+        async def list_users() -> "list[dict[str, Any]]":
+            return [{"id": 1, "name": "Alice"}]
+
+        app = Litestar(
+            route_handlers=[list_users],
+            plugins=[LitestarMCP()],
+            openapi_config=OpenAPIConfig(title="Test API", version="1.0.0"),
+        )
+
+        paths = _openapi_paths(app)
+
+        assert "/users" in paths
+        assert "/mcp" not in paths
+        assert "/.well-known/oauth-protected-resource" not in paths
+        assert "/.well-known/agent-card.json" not in paths
+        assert "/.well-known/mcp-server.json" not in paths
+
+    def test_openapi_schema_includes_plugin_routes_when_configured(self) -> "None":
+        @get("/users", mcp_tool="list_users")
+        async def list_users() -> "list[dict[str, Any]]":
+            return [{"id": 1, "name": "Alice"}]
+
+        app = Litestar(
+            route_handlers=[list_users],
+            plugins=[LitestarMCP(MCPConfig(include_in_schema=True))],
+            openapi_config=OpenAPIConfig(title="Test API", version="1.0.0"),
+        )
+
+        paths = _openapi_paths(app)
+
+        assert "/users" in paths
+        assert "/mcp" in paths
+        assert "/.well-known/oauth-protected-resource" in paths
+        assert "/.well-known/agent-card.json" in paths
+        assert "/.well-known/mcp-server.json" in paths
+
     def test_tool_execution_real(self) -> "None":
         @post("/analyze", opt={"mcp_tool": "analyze_data"})
         async def analyze(data: "dict[str, Any]") -> "dict[str, Any]":
@@ -150,8 +194,6 @@ class TestLitestarMCP:
         assert "error" in result
 
     def test_openapi_integration(self) -> "None":
-        from litestar.openapi.config import OpenAPIConfig
-
         app = Litestar(plugins=[LitestarMCP()], openapi_config=OpenAPIConfig(title="My Custom API", version="2.1.0"))
         client = TestClient(app=app)
 


### PR DESCRIPTION
## Summary

- Applies `MCPConfig.include_in_schema` to the plugin-owned `/.well-known/*` discovery endpoints.
- Keeps user-marked application routes visible in OpenAPI by default.
- Adds OpenAPI regression coverage for the default hidden routes and the `include_in_schema=True` opt-in behavior.
- Adds the requested `0.11.1` changelog bugfix entry.

## Root Cause

`LitestarMCP` already passed `include_in_schema` to the `/mcp` router, but the three discovery route decorators did not receive that flag. Litestar therefore treated `/.well-known/oauth-protected-resource`, `/.well-known/agent-card.json`, and `/.well-known/mcp-server.json` as ordinary OpenAPI routes even when the plugin default was meant to hide MCP plugin routes.