### PR TITLE
fix(release): support Core Metadata 2.5 publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,4 +36,4 @@ jobs:
         run: uv build
 
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1


### PR DESCRIPTION
## Summary

Update the pinned PyPI publishing action to the current `release/v1` commit with Twine 7 support.

The v0.13.0 publish job built valid distributions but the older publisher rejected Core Metadata 2.5 before upload. This keeps trusted publishing and metadata verification enabled while allowing the generated artifacts to pass validation.

Validated with the repository lint gate, pre-commit hooks, and Twine 7 checks against the built wheel and source distribution.